### PR TITLE
Removal of e62e6

### DIFF
--- a/converter_api.py
+++ b/converter_api.py
@@ -246,15 +246,14 @@ async def stats_api(
             # ------------------------------
             # Step 2: Transpile the Query
             # ------------------------------
-            converted_query = sqlglot.transpile(query, read=from_sql, write=to_sql, identify=False)[
-                0
-            ]
-            converted_query = replace_struct_in_query(converted_query)
+            tree = sqlglot.parse_one(query, read=from_sql, error_level=None)
 
-            converted_query_ast = parse_one(converted_query, read=to_sql)
-            double_quotes_added_query = quote_identifiers(converted_query_ast, dialect=to_sql).sql(
-                dialect=to_sql
-            )
+            tree2 = quote_identifiers(tree, dialect=to_sql)
+
+            double_quotes_added_query = tree2.sql(dialect=to_sql, from_dialect=from_sql)
+
+            double_quotes_added_query = replace_struct_in_query(double_quotes_added_query)
+
             double_quotes_added_query = add_comment_to_query(double_quotes_added_query, comment)
 
             all_functions_converted_query = extract_functions_from_query(

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -661,6 +661,7 @@ class Generator(metaclass=_Generator):
         "_identifier_start",
         "_identifier_end",
         "_quote_json_path_key_using_brackets",
+        "from_dialect",
     )
 
     def __init__(
@@ -677,6 +678,7 @@ class Generator(metaclass=_Generator):
         max_text_width: int = 80,
         comments: bool = True,
         dialect: DialectType = None,
+        from_dialect: t.Optional[str] = None,
     ):
         import sqlglot
         from sqlglot.dialects import Dialect
@@ -692,6 +694,7 @@ class Generator(metaclass=_Generator):
         self.max_text_width = max_text_width
         self.comments = comments
         self.dialect = Dialect.get_or_raise(dialect)
+        self.from_dialect = from_dialect
 
         # This is both a Dialect property and a Generator argument, so we prioritize the latter
         self.normalize_functions = (


### PR DESCRIPTION
This PR contains two commits for two functionalities each one hase its own significance. 
1. To remove E6 to E6 where made changes to converter_api.py 
Code flow as a flowchart -[https://excalidraw.com/#json=E581ZjS8GbSQiRpQ2zB3w,nrNIQchcU35l5vkbMWXQdw]

2. As an instance attribute `from_dialect` to get source dialect using which we can manipulate our implementation on E6 side as per source dialect
