### PR TITLE
UnitFix

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -12,7 +12,6 @@ from sqlglot.dialects.dialect import (
     max_or_greatest,
     min_or_least,
     rename_func,
-    unit_to_str,
     timestrtotime_sql,
     datestrtodate_sql,
     trim_sql,
@@ -338,6 +337,17 @@ def format_time_for_parsefunctions(expression):
 def add_single_quotes(expression) -> str:
     quoted_str = f"'{expression}'"
     return quoted_str
+
+
+def unit_to_str(expression: exp.Expression, default: str = "DAY") -> t.Optional[exp.Expression]:
+    unit = expression.args.get("unit")
+
+    if isinstance(unit, exp.Placeholder):
+        return unit
+    if unit:
+        unit_name_new = unit.name.replace("SQL_TSI_", "")
+        return exp.Literal.string(unit_name_new)
+    return exp.Literal.string(default) if default else None
 
 
 def _trim_sql(self: E6.Generator, expression: exp.Trim) -> str:

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -288,14 +288,28 @@ class TestE6(Validator):
         )
 
         self.validate_all(
-            "SELECT FROM_UNIXTIME_WITHUNIT(1674797653, 'milliseconds')",
+            "SELECT DATE_DIFF('DAY', CAST('2024-11-11' AS DATE), CAST('2024-11-09' AS DATE))",
+            read={
+                "databricks": "SELECT DATEDIFF(SQL_TSI_DAY, CAST('2024-11-11' AS DATE), CAST('2024-11-09' AS DATE))",
+            },
+        )
+
+        self.validate_all(
+            "SELECT TIMESTAMP_ADD('HOUR', 1, CAST('2003-01-02 11:59:59' AS TIMESTAMP))",
+            read={
+                "databricks": "SELECT TIMESTAMPADD(SQL_TSI_HOUR, 1, TIMESTAMP'2003-01-02 11:59:59')",
+            },
+        )
+
+        self.validate_all(
+            "SELECT FROM_UNIXTIME(1674797653)",
             read={
                 "trino": "SELECT from_unixtime(1674797653)",
             },
         )
 
         self.validate_all(
-            "SELECT FROM_UNIXTIME_WITHUNIT(unixtime / 1000, 'seconds')",
+            "SELECT FROM_UNIXTIME(unixtime / 1000)",
             read={"trino": "SELECT from_unixtime(unixtime/1000)"},
         )
 


### PR DESCRIPTION
Support for changing `SQL_TSI_unit` to `unit` for UNIT in datetime functions