### PR TITLE
TIMEDIFF to TIMESTAMP_DIFF

### DIFF
--- a/apis/utils/supported_functions_in_all_dialects.json
+++ b/apis/utils/supported_functions_in_all_dialects.json
@@ -784,7 +784,8 @@
         "REDUCE",
         "LAST_DAY_OF_MONTH",
         "FORMAT_DATETIME",
-        "COUNT_IF"
+        "COUNT_IF",
+        "TIMEDIFF"
     ],
     "databricks": [
          "ABS",

--- a/apis/utils/supported_functions_in_all_dialects.json
+++ b/apis/utils/supported_functions_in_all_dialects.json
@@ -784,8 +784,7 @@
         "REDUCE",
         "LAST_DAY_OF_MONTH",
         "FORMAT_DATETIME",
-        "COUNT_IF",
-        "TIMEDIFF"
+        "COUNT_IF"
     ],
     "databricks": [
          "ABS",

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -112,6 +112,9 @@ class Databricks(Spark):
             "REGEXP_SUBSTR": exp.RegexpExtract.from_arg_list,
             "RTRIM": lambda args: build_trim(args, is_left=False),
             "SPLIT_PART": exp.SplitPart.from_arg_list,
+            "TIMEDIFF": lambda args: exp.TimestampDiff(
+                unit=seq_get(args, 0), this=seq_get(args, 1), expression=seq_get(args, 2)
+            ),
         }
 
         FACTOR = {

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -564,6 +564,45 @@ class TestE6(Validator):
             "SELECT CAST(col AS JSON)",
             read={"databricks": "select cast(col as JSON)"},
         )
+        for unit in ["SECOND", "MINUTE", "HOUR", "DAY", "WEEK", "MONTH", "YEAR"]:
+            self.validate_all(
+                f"SELECT TIMESTAMP_DIFF(date1, date2, '{unit}')",
+                read={
+                    "databricks": f"SELECT TIMEDIFF('{unit}', date1, date2)",
+                },
+                write={
+                    "e6": f"SELECT TIMESTAMP_DIFF(date1, date2, '{unit}')",
+                },
+            )
+
+            self.validate_all(
+                "SELECT TIMESTAMP_DIFF(start1, end1, 'HOUR'), TIMESTAMP_DIFF(start2, end2, 'MINUTE')",
+                read={
+                    "databricks": "SELECT TIMEDIFF('HOUR', start1, end1), TIMEDIFF('MINUTE', start2, end2)",
+                },
+                write={
+                    "e6": "SELECT TIMESTAMP_DIFF(start1, end1, 'HOUR'), TIMESTAMP_DIFF(start2, end2, 'MINUTE')",
+                },
+            )
+
+            self.validate_all(
+                "SELECT ABS(TIMESTAMP_DIFF(start_time, end_time, 'MINUTE'))",
+                read={
+                    "databricks": "SELECT ABS(TIMEDIFF('MINUTE', start_time, end_time))",
+                },
+                write={
+                    "e6": "SELECT ABS(TIMESTAMP_DIFF(start_time, end_time, 'MINUTE'))",
+                },
+            )
+            self.validate_all(
+                "SELECT AVG(TIMESTAMP_DIFF(start_time, end_time, 'HOUR')) FROM sessions",
+                read={
+                    "databricks": "SELECT AVG(TIMEDIFF('HOUR', start_time, end_time)) FROM sessions",
+                },
+                write={
+                    "e6": "SELECT AVG(TIMESTAMP_DIFF(start_time, end_time, 'HOUR')) FROM sessions",
+                },
+            )
 
     def test_regex(self):
         self.validate_all(


### PR DESCRIPTION
This PR updates the SQL translation logic to replace usage of the TIMEDIFF function with the more precise and dialect-consistent TIMESTAMP_DIFF function.