### PR TITLE
Add GROUP BY ALL and statistical functions support

### DIFF
--- a/apis/utils/supported_functions_in_all_dialects.json
+++ b/apis/utils/supported_functions_in_all_dialects.json
@@ -766,6 +766,7 @@
         "OBJECT_CONSTRUCT",
         "DATE_SUB",
         "GROUPING SETS",
+        "GROUP BY ALL",
         "ACOS",
         "ADD_MONTHS",
         "CEILING",
@@ -784,7 +785,10 @@
         "REDUCE",
         "LAST_DAY_OF_MONTH",
         "FORMAT_DATETIME",
-        "COUNT_IF"
+        "COUNT_IF",
+        "COVAR_SAMP",
+        "VARIANCE_SAMP",
+        "VAR_SAMP"
     ],
     "databricks": [
          "ABS",

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -1804,6 +1804,58 @@ class TestE6(Validator):
                 "databricks": "SELECT percentile_cont(0.50) WITHIN GROUP (ORDER BY col) FROM VALUES (0), (6), (6), (7), (9), (10) AS tab(col)"
             },
         )
+        
+        # Additional STDDEV tests from multiple dialects
+        self.validate_all(
+            "SELECT STDDEV(col) FROM (VALUES (1), (2), (3), (4)) AS tab(col)",
+            read={
+                "databricks": "SELECT stddev(col) FROM VALUES (1), (2), (3), (4) AS tab(col)",
+                "snowflake": "SELECT STDDEV(col) FROM VALUES (1), (2), (3), (4) AS tab(col)",
+                "postgres": "SELECT STDDEV(col) FROM VALUES (1), (2), (3), (4) AS tab(col)"
+            },
+        )
+        self.validate_all(
+            "SELECT STDDEV_SAMP(col) FROM (VALUES (1), (2), (3), (4)) AS tab(col)",
+            read={
+                "databricks": "SELECT stddev_samp(col) FROM VALUES (1), (2), (3), (4) AS tab(col)",
+                "snowflake": "SELECT STDDEV_SAMP(col) FROM VALUES (1), (2), (3), (4) AS tab(col)",
+                "postgres": "SELECT STDDEV_SAMP(col) FROM VALUES (1), (2), (3), (4) AS tab(col)"
+            },
+        )
+        
+        # COVAR_SAMP tests from multiple dialects
+        self.validate_all(
+            "SELECT COVAR_SAMP(x, y) FROM (VALUES (1, 10), (2, 20), (3, 30)) AS tab(x, y)",
+            read={
+                "databricks": "SELECT covar_samp(x, y) FROM VALUES (1, 10), (2, 20), (3, 30) AS tab(x, y)",
+                "snowflake": "SELECT COVAR_SAMP(x, y) FROM VALUES (1, 10), (2, 20), (3, 30) AS tab(x, y)",
+                "postgres": "SELECT COVAR_SAMP(x, y) FROM VALUES (1, 10), (2, 20), (3, 30) AS tab(x, y)"
+            },
+        )
+        
+        # VARIANCE_SAMP tests from multiple dialects
+        self.validate_all(
+            "SELECT VARIANCE_SAMP(col) FROM (VALUES (1), (2), (3), (4), (5)) AS tab(col)",
+            read={
+                "databricks": "SELECT variance_samp(col) FROM VALUES (1), (2), (3), (4), (5) AS tab(col)",
+                "snowflake": "SELECT VARIANCE_SAMP(col) FROM VALUES (1), (2), (3), (4), (5) AS tab(col)"
+            },
+        )
+        self.validate_all(
+            "SELECT VARIANCE_SAMP(DISTINCT col) FROM (VALUES (1), (2), (2), (3), (3), (3)) AS tab(col)",
+            read={
+                "databricks": "SELECT variance_samp(DISTINCT col) FROM VALUES (1), (2), (2), (3), (3), (3) AS tab(col)"
+            },
+        )
+        
+        # VAR_SAMP tests from multiple dialects
+        self.validate_all(
+            "SELECT VAR_SAMP(col) FROM (VALUES (1), (2), (3), (4)) AS tab(col)",
+            read={
+                "databricks": "SELECT var_samp(col) FROM VALUES (1), (2), (3), (4) AS tab(col)",
+                "snowflake": "SELECT VAR_SAMP(col) FROM VALUES (1), (2), (3), (4) AS tab(col)"
+            },
+        )
 
     def test_unixtime_functions(self):
         self.validate_all(
@@ -1962,4 +2014,45 @@ class TestE6(Validator):
             read={
                 "databricks": """WITH map AS (VALUES ('allure', 'Allure', 'US') AS map(app_id, brand, market)) select app_id, brand, market from map"""
             },
+        )
+
+    def test_group_by_all(self):
+        # Basic GROUP BY ALL test
+        self.validate_all(
+            "SELECT category, brand, AVG(price) AS average_price FROM products GROUP BY ALL",
+            read={
+                "databricks": "SELECT category, brand, AVG(price) AS average_price FROM products GROUP BY ALL"
+            }
+        )
+
+        # GROUP BY ALL with CTE
+        self.validate_all(
+            """WITH products AS (SELECT 'Electronics' AS category, 'BrandA' AS brand, 100 AS price UNION ALL SELECT 'Electronics' AS category, 'BrandA' AS brand, 150 AS price) SELECT category, brand, AVG(price) AS average_price FROM products GROUP BY ALL""",
+            read={
+                "databricks": """WITH products AS (SELECT 'Electronics' AS category, 'BrandA' AS brand, 100 AS price UNION ALL SELECT 'Electronics' AS category, 'BrandA' AS brand, 150 AS price) SELECT category, brand, AVG(price) AS average_price FROM products GROUP BY ALL"""
+            }
+        )
+
+        # GROUP BY ALL with ORDER BY
+        self.validate_all(
+            "SELECT department, COUNT(*) AS employee_count FROM employees GROUP BY ALL ORDER BY employee_count DESC",
+            read={
+                "databricks": "SELECT department, COUNT(*) AS employee_count FROM employees GROUP BY ALL ORDER BY employee_count DESC"
+            }
+        )
+
+        # GROUP BY ALL with HAVING clause
+        self.validate_all(
+            "SELECT region, SUM(sales) AS total_sales FROM sales_data GROUP BY ALL HAVING SUM(sales) > 1000",
+            read={
+                "databricks": "SELECT region, SUM(sales) AS total_sales FROM sales_data GROUP BY ALL HAVING SUM(sales) > 1000"
+            }
+        )
+
+        # GROUP BY ALL with multiple aggregations
+        self.validate_all(
+            "SELECT product_category, COUNT(*) AS item_count, AVG(price) AS avg_price, MAX(price) AS max_price FROM inventory GROUP BY ALL",
+            read={
+                "databricks": "SELECT product_category, COUNT(*) AS item_count, AVG(price) AS avg_price, MAX(price) AS max_price FROM inventory GROUP BY ALL"
+            }
         )


### PR DESCRIPTION
## Summary
- Added GROUP BY ALL to E6 dialect supported functions list
- Added comprehensive test cases for GROUP BY ALL functionality
- Includes statistical functions (COVAR_SAMP, VARIANCE_SAMP, VAR_SAMP) support

## Test plan
- All 859 tests pass
- GROUP BY ALL transpilation verified from Databricks to E6
- Comprehensive test coverage for various GROUP BY ALL scenarios