### PR TITLE
Add TRANSLATE, TYPEOF, and FIND_IN_SET function mappings

### DIFF
--- a/apis/utils/supported_functions_in_all_dialects.json
+++ b/apis/utils/supported_functions_in_all_dialects.json
@@ -785,7 +785,11 @@
         "REDUCE",
         "LAST_DAY_OF_MONTH",
         "FORMAT_DATETIME",
-        "COUNT_IF"
+        "COUNT_IF",
+        "TRANSLATE",
+        "SPACE",
+        "typeof"
+
     ],
     "databricks": [
          "ABS",

--- a/apis/utils/supported_functions_in_all_dialects.json
+++ b/apis/utils/supported_functions_in_all_dialects.json
@@ -740,6 +740,7 @@
         "DISTINCT",
         "STDDEV",
         "FILTER_ARRAY",
+        "FIND_IN_SET",
         "TIMESTAMP",
         "REGEXP_CONTAINS",
         "CASE",

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -105,6 +105,7 @@ class Databricks(Spark):
             "DATE_ADD": build_date_delta(exp.DateAdd),
             "DATEDIFF": build_date_delta(exp.DateDiff),
             "DATE_DIFF": build_date_delta(exp.DateDiff),
+            "FIND_IN_SET": exp.FindInSet.from_arg_list,
             "GETDATE": exp.CurrentTimestamp.from_arg_list,
             "GET_JSON_OBJECT": _build_json_extract,
             "TO_DATE": build_formatted_time(exp.TsOrDsToDate, "databricks"),

--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -1547,6 +1547,9 @@ class E6(Dialect):
             ),
             "TRUNC": date_trunc_to_time,
             "TRIM": lambda self: self._parse_trim(),
+            "TYPEOF": lambda args: exp.TypeOf(
+                this=seq_get(args, 0)
+            ),
             "UNNEST": lambda args: exp.Explode(this=seq_get(args, 0)),
             # TODO:: I have removed the _parse_unnest_sql, was it really required
             # It was added due to some requirements before but those were asked to remove afterwards so it should not matter now
@@ -2215,6 +2218,7 @@ class E6(Dialect):
             exp.ArgMax: rename_func("MAX_BY"),
             exp.ArgMin: rename_func("MIN_BY"),
             exp.Array: array_sql,
+            exp.TypeOf: rename_func("TYPEOF"),
             exp.ArrayAgg: rename_func("ARRAY_AGG"),
             exp.ArrayConcat: rename_func("ARRAY_CONCAT"),
             exp.ArrayContains: rename_func("ARRAY_CONTAINS"),

--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -2137,6 +2137,26 @@ class E6(Dialect):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
             exp.Anonymous: anonymous_sql,
+            # FIND_IN_SET transformation for E6 dialect
+            # 
+            # Databricks FIND_IN_SET(searchExpr, sourceExpr) documentation:
+            # - Returns the position of a string within a comma-separated list of strings
+            # - searchExpr: A STRING expression specifying the "word" to be searched
+            # - sourceExpr: A STRING expression with commas separating "words"  
+            # - Returns: An INTEGER (1-based position). Returns 0 if not found or searchExpr contains comma
+            # - Example: SELECT find_in_set('ab','abc,b,ab,c,def'); returns 3
+            #
+            # E6 Implementation Logic:
+            # - FIND_IN_SET('ab', 'abc,b,ab,c,def') becomes ARRAY_POSITION('ab', SPLIT('abc,b,ab,c,def', ','))
+            # - SPLIT('abc,b,ab,c,def', ',') creates ['abc', 'b', 'ab', 'c', 'def']
+            # - ARRAY_POSITION finds 1-based position of 'ab' in the array = 3
+            # - Note: E6's ARRAY_POSITION signature is (element, array) not (array, element)
+            # - This preserves exact same behavior: 1-based indexing, returns 0/NULL if not found
+            exp.FindInSet: lambda self, e: self.func(
+                "ARRAY_POSITION", 
+                e.this,
+                self.func("SPLIT", e.expression, exp.Literal.string(","))
+            ),
             exp.AnyValue: rename_func("ARBITRARY"),
             exp.ApproxDistinct: rename_func("APPROX_COUNT_DISTINCT"),
             exp.ApproxQuantile: rename_func("APPROX_PERCENTILE"),

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -372,6 +372,7 @@ class Hive(Dialect):
                 args or [exp.CurrentTimestamp()]
             ),
             "YEAR": lambda args: exp.Year(this=exp.TsOrDsToDate.from_arg_list(args)),
+            "TRANSLATE": exp.Translate.from_arg_list,
         }
 
         NO_PAREN_FUNCTION_PARSERS = {

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -118,6 +118,9 @@ class Spark(Spark2):
             "TIMESTAMPDIFF": build_date_delta(exp.TimestampDiff),
             "DATEDIFF": _build_datediff,
             "DATE_DIFF": _build_datediff,
+            "TYPEOF": lambda args: exp.TypeOf(
+                this=seq_get(args, 0)
+            ),
             "TIMESTAMP_LTZ": _build_as_cast("TIMESTAMP_LTZ"),
             "TIMESTAMP_NTZ": _build_as_cast("TIMESTAMP_NTZ"),
             "TRY_ELEMENT_AT": lambda args: exp.Bracket(

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6966,6 +6966,11 @@ class Trim(Func):
     }
 
 
+class Translate(Func):
+    """Standard SQL TRANSLATE function for character replacement."""
+    arg_types = {"this": True, "from": True, "to": True}
+
+
 class TsOrDsAdd(Func, TimeUnit):
     # return_type is used to correctly cast the arguments of this expression when transpiling it
     arg_types = {"this": True, "expression": True, "unit": False, "return_type": False}

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6835,6 +6835,20 @@ class StrPosition(Func):
     }
 
 
+class FindInSet(Func):
+    """
+    FIND_IN_SET function that returns the position of a string within a comma-separated list of strings.
+    
+    Returns:
+        The position (1-based) of searchExpr in sourceExpr, or 0 if not found or if searchExpr contains a comma.
+    
+    Args:
+        this: The string to search for (searchExpr)
+        expression: The comma-separated list of strings to search in (sourceExpr)
+    """
+    arg_types = {"this": True, "expression": True}
+
+
 class StrToDate(Func):
     arg_types = {"this": True, "format": False, "safe": False}
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5494,6 +5494,9 @@ class Array(Func):
 class ToArray(Func):
     pass
 
+class TypeOf(Func):
+    arg_types = {"this": True}
+
 
 # https://materialize.com/docs/sql/types/list/
 class List(Func):

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -565,6 +565,29 @@ class TestE6(Validator):
             read={"databricks": "select cast(col as JSON)"},
         )
 
+        # FIND_IN_SET function tests - Databricks to E6 transpilation
+        self.validate_all(
+            "SELECT ARRAY_POSITION('ab', SPLIT('abc,b,ab,c,def', ','))",
+            read={
+                "databricks": "SELECT FIND_IN_SET('ab', 'abc,b,ab,c,def')",
+            },
+        )
+
+        self.validate_all(
+            "SELECT ARRAY_POSITION('test', SPLIT('hello,world,test', ','))",
+            read={
+                "databricks": "SELECT FIND_IN_SET('test', 'hello,world,test')",
+            },
+        )
+
+        # Test FIND_IN_SET with column references
+        self.validate_all(
+            "SELECT ARRAY_POSITION(search_col, SPLIT(list_col, ',')) FROM table1",
+            read={
+                "databricks": "SELECT FIND_IN_SET(search_col, list_col) FROM table1",
+            },
+        )
+
     def test_regex(self):
         self.validate_all(
             "REGEXP_REPLACE('abcd', 'ab', '')",

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -33,6 +33,16 @@ class TestE6(Validator):
             },
         )
 
+        self.validate_all(
+            "SELECT REPLACE(REPLACE(REPLACE(LOWER('AaBbCc'), 'a', '1'), 'b', '2'), 'c', '3')",
+            read={
+                "databricks":"SELECT TRANSLATE('AaBbCc' COLLATE UTF8_LCASE, 'abc', '123')",
+                "spark":"SELECT TRANSLATE('AaBbCc' COLLATE UTF8_LCASE, 'abc', '123')",
+                "spark2":"SELECT TRANSLATE('AaBbCc' COLLATE UTF8_LCASE, 'abc', '123')",
+            }
+
+        )
+
         # Concat in dbr can accept many datatypes of args, but we map it to array_concat if type is of array. So we decided to put it as it is.
         self.validate_all(
             "SELECT CONCAT(TRANSFORM(ARRAY[1, 2], x -> x * 10), ARRAY[30, 40])",

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -43,6 +43,14 @@ class TestE6(Validator):
 
         )
 
+        self.validate_all(
+            "SELECT TYPEOF('hello')",
+        read={"databricks":"SELECT TYPEOF('hello');",
+              "spark":"SELECT TYPEOF('hello');",
+              "spark2":"SELECT TYPEOF('hello');",
+              "snowflake":"SELECT TYPEOF('hello');",}
+        )
+
         # Concat in dbr can accept many datatypes of args, but we map it to array_concat if type is of array. So we decided to put it as it is.
         self.validate_all(
             "SELECT CONCAT(TRANSFORM(ARRAY[1, 2], x -> x * 10), ARRAY[30, 40])",


### PR DESCRIPTION
 ## Summary
  - Added TRANSLATE to REPLACE function mapping for Databricks to E6 conversion
  - Added TYPEOF function mapping support
  - Added FIND_IN_SET function mapping from Databricks to E6
  - Note: TYPEOF function doesn't support custom datatypes created at runtime

  ## Changes
  - Added TRANSLATE, TYPEOF, and FIND_IN_SET to supported functions list
  - Implemented TRANSLATE to REPLACE conversion logic in E6 dialect
  - Implemented FIND_IN_SET mapping in E6 dialect
  - Added comprehensive test cases for all three functions
  - Updated Databricks, Hive, and Spark dialects to support these functions