### PR TITLE
Zepto saturday, sunday issue sorted

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -2378,6 +2378,13 @@ class E6(Dialect):
             "percent_rank",
             "rank",
             "row_number",
+            "sunday",
+            "monday",
+            "tuesday",
+            "wednesday",
+            "thursday",
+            "friday",
+            "saturday",
         }
 
         UNSIGNED_TYPE_MAPPING = {

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -42,6 +42,11 @@ class TestE6(Validator):
         )
 
         self.validate_all(
+            "SELECT SUM(CASE WHEN week_Day = 7 THEN a END) AS \"Saturday\"",
+            read={"databricks":"SELECT sum(case when week_Day = 7 then a end) as Saturday"}
+        )
+
+        self.validate_all(
             "POWER(x, 2)",
             read={
                 "bigquery": "POWER(x, 2)",


### PR DESCRIPTION
  Added weekday names (Monday through Sunday) to the E6 dialect's reserved keywords list to ensure proper quoting when used as column names or aliases.

  Problem

  - Queries using day names as column aliases (e.g., AS Saturday) were failing with parse errors
  - E6 was treating day names as keywords but sqlglot wasn't quoting them
  - Case sensitivity mismatches between inner queries (AS Saturday) and outer references (saturday) caused errors

  Solution

  Added all seven day names to the RESERVED_KEYWORDS set in the E6 dialect:
  - monday, tuesday, wednesday, thursday, friday, saturday, sunday

  Impact

  - Day names are now automatically quoted when used as identifiers
  - Prevents parse errors like Encountered " "SATURDAY" "Saturday ""
  - Maintains case sensitivity with proper quoting (e.g., "Saturday" vs "saturday")
  - Fixes Zepto dashboard queries that use day names for pivot-style reports

  Example

  -- Before: Would fail with parse error
  SELECT SUM(CASE WHEN week_day = 7 THEN a END) AS Saturday

  -- After: Properly quoted
  SELECT SUM(CASE WHEN week_day = 7 THEN a END) AS "Saturday"