### PR TITLE
Json prob

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -1483,7 +1483,6 @@ class E6(Dialect):
             # "TO_DATE":  _build_datetime("TO_DATE", exp.DataType.Type.DATE),
             "TO_HEX": exp.Hex.from_arg_list,
             "TO_JSON": exp.JSONFormat.from_arg_list,
-            "TO_JSON_STRING": exp.JSONFormat.from_arg_list,
             "TO_TIMESTAMP": _build_datetime("TO_TIMESTAMP", exp.DataType.Type.TIMESTAMP),
             "TO_TIMESTAMP_NTZ": _build_datetime("TO_TIMESTAMP_NTZ", exp.DataType.Type.TIMESTAMP),
             "TO_UTF8": lambda args: exp.Encode(
@@ -2158,14 +2157,17 @@ class E6(Dialect):
         def json_format_sql(self, expression: exp.JSONFormat) -> str:
             inner = expression.this
             if isinstance(inner, exp.Cast) and inner.to.this == exp.DataType.Type.JSON:
-                return self.func("TO_JSON_STRING", inner.this)
+                return self.func("TO_JSON", inner.this)
             return self.func("TO_JSON", inner)
 
         def json_extract_sql(self, e: exp.JSONExtract | exp.JSONExtractScalar):
             path = e.expression
             if self.from_dialect == "databricks":
-                path = self.sql(path) if not self.sql(path).startswith("$") else self.sql(path)
-                #path = add_single_quotes(path)
+                if not self.sql(path).startswith("'$."):
+                    path = add_single_quotes("$." + self.sql(path))
+                else:
+                    path = self.sql(path)
+
             return self.func("JSON_EXTRACT", e.this, path)
 
         def split_sql(self, expression: exp.Split | exp.RegexpSplit):

--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -2164,8 +2164,8 @@ class E6(Dialect):
         def json_extract_sql(self, e: exp.JSONExtract | exp.JSONExtractScalar):
             path = e.expression
             if self.from_dialect == "databricks":
-                path = "$." + path if not path.startswith("$") else path
-                path = add_single_quotes(path)
+                path = self.sql(path) if not self.sql(path).startswith("$") else self.sql(path)
+                #path = add_single_quotes(path)
             return self.func("JSON_EXTRACT", e.this, path)
 
         def split_sql(self, expression: exp.Split | exp.RegexpSplit):

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -888,9 +888,9 @@ def eliminate_join_marks(expression: exp.Expression) -> exp.Expression:
                 continue
 
             predicate = column.find_ancestor(exp.Predicate, exp.Select)
-            assert isinstance(
-                predicate, exp.Binary
-            ), "Columns can only be marked with (+) when involved in a binary operation"
+            assert isinstance(predicate, exp.Binary), (
+                "Columns can only be marked with (+) when involved in a binary operation"
+            )
 
             predicate_parent = predicate.parent
             join_predicate = predicate.pop()
@@ -902,9 +902,9 @@ def eliminate_join_marks(expression: exp.Expression) -> exp.Expression:
                 c for c in join_predicate.right.find_all(exp.Column) if c.args.get("join_mark")
             ]
 
-            assert not (
-                left_columns and right_columns
-            ), "The (+) marker cannot appear in both sides of a binary predicate"
+            assert not (left_columns and right_columns), (
+                "The (+) marker cannot appear in both sides of a binary predicate"
+            )
 
             marked_column_tables = set()
             for col in left_columns or right_columns:
@@ -914,9 +914,9 @@ def eliminate_join_marks(expression: exp.Expression) -> exp.Expression:
                 col.set("join_mark", False)
                 marked_column_tables.add(table)
 
-            assert (
-                len(marked_column_tables) == 1
-            ), "Columns of only a single table can be marked with (+) in a given binary predicate"
+            assert len(marked_column_tables) == 1, (
+                "Columns of only a single table can be marked with (+) in a given binary predicate"
+            )
 
             # Add predicate if join already copied, or add join if it is new
             join_this = old_joins.get(col.table, query_from).this
@@ -938,9 +938,9 @@ def eliminate_join_marks(expression: exp.Expression) -> exp.Expression:
         only_old_join_sources = old_joins.keys() - new_joins.keys()
 
         if query_from.alias_or_name in new_joins:
-            assert (
-                len(only_old_join_sources) >= 1
-            ), "Cannot determine which table to use in the new FROM clause"
+            assert len(only_old_join_sources) >= 1, (
+                "Cannot determine which table to use in the new FROM clause"
+            )
 
             new_from_name = list(only_old_join_sources)[0]
             query.set("from", exp.From(this=old_joins.pop(new_from_name).this))

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -64,6 +64,7 @@ class Validator(unittest.TestCase):
                         unsupported_level=ErrorLevel.IGNORE,
                         pretty=pretty,
                         identify=identify,
+                        from_dialect=read_dialect,
                     ),
                     sql,
                 )

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -547,15 +547,14 @@ class TestE6(Validator):
             },
         )
 
-
-        # self.validate_all(
-        #     "SELECT JSON_EXTRACT(c1, '$.item[1].price')",
-        #     read={"databricks": "SELECT GET_JSON_OBJECT(c1, '$.item[1].price')"},
-        # )
-        # self.validate_all(
-        #     "SELECT JSON_EXTRACT(c1, '$.box[1].price')",
-        #     read={"SELECT c1:box[1].price"},
-        # )
+        self.validate_all(
+            "SELECT JSON_EXTRACT(c1, '$.item[1].price')",
+            read={"databricks": "SELECT GET_JSON_OBJECT(c1, '$.item[1].price')"},
+        )
+        self.validate_all(
+            "SELECT JSON_EXTRACT(c1, '$.box[1].price')",
+            read={"databricks": "SELECT c1:box[1].price"},
+        )
 
         self.validate_all(
             "TO_JSON(X)",

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -547,8 +547,18 @@ class TestE6(Validator):
             },
         )
 
+
+        # self.validate_all(
+        #     "SELECT JSON_EXTRACT(c1, '$.item[1].price')",
+        #     read={"databricks": "SELECT GET_JSON_OBJECT(c1, '$.item[1].price')"},
+        # )
+        # self.validate_all(
+        #     "SELECT JSON_EXTRACT(c1, '$.box[1].price')",
+        #     read={"SELECT c1:box[1].price"},
+        # )
+
         self.validate_all(
-            "TO_JSON_STRING(X)",
+            "TO_JSON(X)",
             read={
                 "presto": "JSON_FORMAT(CAST(X as JSON))",
             },


### PR DESCRIPTION
 Summary

  - Fixed JSONPath object handling in json_extract_sql function for E6 dialect
  - Prevents double-quoting issues like '$.'$.path'' in generated SQL
  - Ensures proper $.path format when converting from Databricks to E6
  - Updated test framework to pass from_dialect parameter to generator

  Problem

  When transpiling JSON extraction queries from Databricks to E6, the json_extract_sql function was:
  1. Treating JSONPath objects as strings, causing AttributeError: 'JSONPath' object has no attribute 'startswith'
  2. Creating malformed JSON paths with double quotes: JSON_EXTRACT(meta, '$.'$.bincounttaskmeta'')
  3. Not preserving proper $. prefix in output
  ****4. Test framework wasn't passing from_dialect parameter, causing conditional logic to be skipped****
  
  ****
  NOTE-
  1. Test framework creates separate parser instances for each dialect in the read dictionary
  2. The e6 generator doesn't know the source dialect when processing the parsed AST
  3. self.from_dialect is None or empty in the generator context
  4. The condition fails, so JSON path processing is skipped
  5. Raw path without quotes gets passed to self.func()
  ****