### PR TITLE
CAST used with JSON_EXTRACT issue

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -135,11 +135,8 @@ class Databricks(Spark):
         def _parse_colon_as_variant_extract(
             self, this: t.Optional[exp.Expression]
         ) -> t.Optional[exp.Expression]:
-            """Override to set json_query=True for Databricks colon syntax"""
+            """Override for Databricks colon syntax - variant_extract flag is set by parent"""
             result = super()._parse_colon_as_variant_extract(this)
-            if isinstance(result, exp.JSONExtract):
-                result.set("json_query", True)
-
             return result
 
     class Generator(Spark.Generator):

--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -1318,6 +1318,8 @@ class E6(Dialect):
         In this context, the AST would be structured as follows:
         """
 
+        COLON_IS_VARIANT_EXTRACT = True
+
         # Define the set of data types that are supported for casting operations in the E6 dialect.
 
         SUPPORTED_CAST_TYPES = {
@@ -2250,12 +2252,12 @@ class E6(Dialect):
             return self.func("TO_JSON", inner)
 
         def json_extract_sql(self, e: exp.JSONExtract | exp.JSONExtractScalar):
-            # Check if this is Databricks colon syntax (marked with json_query=True)
-            json_query_flag = getattr(e, "json_query", False) or e.args.get("json_query", False)
+            # Check if this is Databricks colon syntax (marked with variant_extract=True)
+            variant_extract_flag = getattr(e, "variant_extract", False) or e.args.get(
+                "variant_extract", False
+            )
 
-            if self.from_dialect == "databricks" and json_query_flag:
-                # Only preserve simple colon syntax for Databricks variant extraction
-                # Complex paths with brackets/subscripts should use JSON_EXTRACT
+            if self.from_dialect == "databricks" and variant_extract_flag:
                 if isinstance(e.expression, exp.JSONPath):
                     # Check if this is a simple path (only JSONPathRoot + single JSONPathKey)
                     path_expressions = e.expression.expressions

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -571,6 +571,13 @@ class TestE6(Validator):
         )
 
         self.validate_all(
+            'SELECT CAST(STAFF:is_active AS BOOLEAN) AS "staff_is_active" FROM silver_mongo.tms.staffs LIMIT 100',
+            read={
+                "databricks": "SELECT STAFF:is_active::boolean AS `staff_is_active` FROM silver_mongo.tms.staffs LIMIT 100"
+            },
+        )
+
+        self.validate_all(
             "TO_JSON(X)",
             read={
                 "presto": "JSON_FORMAT(CAST(X as JSON))",


### PR DESCRIPTION
When transpiling SQL from Databricks to e6 dialect, colon syntax (:) for JSON field access was being incorrectly converted to JSON_EXTRACT function calls
  instead of preserving the native colon syntax that e6 supports.

  Before:
  -- Databricks input
  SELECT STAFF:is_active::boolean AS staff_is_active FROM table

  -- e6 output (incorrect)
  SELECT CAST(JSON_EXTRACT(STAFF, '$.is_active') AS BOOLEAN) AS "staff_is_active" FROM table


  -- e6 output (correct)
  SELECT CAST(STAFF:is_active AS BOOLEAN) AS "staff_is_active" FROM table