### PR TITLE
Fix JSON_EXTRACT bracket notation path for get_json_object

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -2785,7 +2785,11 @@ class E6(Dialect):
 
                 if not is_placeholder:
                     if not path_sql.startswith("'$."):
-                        path = add_single_quotes("$." + path_sql)
+                        if path_sql.startswith("["):
+                            escaped = ("$" + path_sql).replace("'", "\\'")
+                            path = f"'{escaped}'"
+                        else:
+                            path = add_single_quotes("$." + path_sql)
                     else:
                         path = path_sql
 

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -1301,6 +1301,30 @@ class TestE6(Validator):
             read={"databricks": "SELECT FROM_JSON(GET_JSON_OBJECT(ra1_0.attributesJSON, ?), ?)"},
         )
 
+        # Bracket notation: get_json_object with $['key'] path (map/array access)
+        self.validate_all(
+            """SELECT JSON_EXTRACT(ra1_0.attributesWithLinkTypeJSON, '$[\\'DestinationAccessLinkType:assets:dataRetention\\']')""",
+            read={
+                "databricks": """SELECT GET_JSON_OBJECT(ra1_0.attributesWithLinkTypeJSON, '$[\\'DestinationAccessLinkType:assets:dataRetention\\']')""",
+            },
+        )
+
+        # Dot notation: get_json_object with $.field path (struct access)
+        self.validate_all(
+            "SELECT JSON_EXTRACT(endpoints, '$.youtube')",
+            read={
+                "databricks": "SELECT GET_JSON_OBJECT(endpoints, '$.youtube')",
+            },
+        )
+
+        # Dot notation: nested path
+        self.validate_all(
+            "SELECT JSON_EXTRACT(col, '$.foo.bar')",
+            read={
+                "databricks": "SELECT GET_JSON_OBJECT(col, '$.foo.bar')",
+            },
+        )
+
     def test_array_slice(self):
         self.validate_all(
             "SELECT ARRAY_SLICE(A, B, C + B)",

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -1303,9 +1303,9 @@ class TestE6(Validator):
 
         # Bracket notation: get_json_object with $['key'] path (map/array access)
         self.validate_all(
-            """SELECT JSON_EXTRACT(ra1_0.attributesWithLinkTypeJSON, '$[\\'DestinationAccessLinkType:assets:dataRetention\\']')""",
+            r"""SELECT JSON_EXTRACT(ra1_0.attributesWithLinkTypeJSON, '$[\'DestinationAccessLinkType:assets:dataRetention\']')""",
             read={
-                "databricks": """SELECT GET_JSON_OBJECT(ra1_0.attributesWithLinkTypeJSON, '$[\\'DestinationAccessLinkType:assets:dataRetention\\']')""",
+                "databricks": r"""SELECT GET_JSON_OBJECT(ra1_0.attributesWithLinkTypeJSON, '$[\'DestinationAccessLinkType:assets:dataRetention\']')""",
             },
         )
 


### PR DESCRIPTION
## Summary
- Fixes `get_json_object(col, '$[\'key\']')` transpilation to `JSON_EXTRACT(col, '$[\'key\']')`
- Previously produced incorrect `JSON_EXTRACT(col, '$.['key']')` — extra `.` after `$` and unescaped inner quotes
- Bracket notation (`$['key']`) is used for map/array access with special character keys
- Dot notation (`$.field`) continues to work unchanged

## Changes
- `e6.py`: In `json_extract_sql`, when path starts with `[`, prepend `$` (not `$.`) and escape inner single quotes
- `test_e6.py`: Added 3 test cases for bracket notation, simple dot path, and nested dot path

## Test plan
- [x] All 47 e6 tests pass (855 subtests)
- [x] Bracket path: `$['key']` → `$[\'key\']` (fixed)
- [x] Dot path: `$.youtube` → `$.youtube` (unchanged)
- [x] Nested dot path: `$.foo.bar` → `$.foo.bar` (unchanged)
- [x] Colon syntax: `col:field` → `col:field` (unchanged)
- [x] Placeholder: `?` → `?` (unchanged)