### PR TITLE
Add Grafana logging for environment and feature flags

### DIFF
--- a/converter_api.py
+++ b/converter_api.py
@@ -60,6 +60,14 @@ if ENABLE_GUARDRAIL.lower() == "true":
     storage_service_client = StorageServiceClient(host=STORAGE_ENGINE_URL, port=STORAGE_ENGINE_PORT)
 
 logger.info("Storage Service Client is created")
+logger.info(
+    "Environment flags — ENABLE_GUARDRAIL: %s, SKIP_COMMENT: %s, "
+    "STORAGE_ENGINE_URL: %s, STORAGE_ENGINE_PORT: %s",
+    ENABLE_GUARDRAIL,
+    SKIP_COMMENT,
+    STORAGE_ENGINE_URL,
+    STORAGE_ENGINE_PORT,
+)
 
 
 def escape_unicode(s: str) -> str:
@@ -119,11 +127,15 @@ async def convert_query(
 
         if SKIP_COMMENT.lower() == "true":
             query, comment = strip_comment(query)
+            logger.info("%s — SKIP_COMMENT: stripped comments", query_id)
+
         tree = sqlglot.parse_one(query, read=from_sql, error_level=None)
 
         if flags_dict.get("USE_TWO_PHASE_QUALIFICATION_SCHEME", False):
+            logger.info("%s — USE_TWO_PHASE_QUALIFICATION_SCHEME: enabled", query_id)
             # Check if we should only transform catalog.schema without full transpilation
             if flags_dict.get("SKIP_E6_TRANSPILATION", False):
+                logger.info("%s — SKIP_E6_TRANSPILATION: enabled", query_id)
                 transformed_query = transform_catalog_schema_only(query, from_sql)
                 # transformed_query = add_comment_to_query(transformed_query, comment)
                 logger.info(
@@ -150,6 +162,7 @@ async def convert_query(
 
         # Preserve original formatting if enabled via feature flag
         if flags_dict.get("PRESERVE_FORMATTING", False):
+            logger.info("%s — PRESERVE_FORMATTING: enabled", query_id)
             double_quotes_added_query = preserve_formatting(
                 query, double_quotes_added_query, from_sql, to_sql
             )


### PR DESCRIPTION
## Summary
- Logs all environment flag values at server startup for visibility in Grafana
- Adds per-request logging when each flag is triggered during query transpilation

## Flags logged
| Flag | When logged |
|------|-------------|
| ENABLE_GUARDRAIL | Startup |
| SKIP_COMMENT | Startup + per-request when comments are stripped |
| STORAGE_ENGINE_URL | Startup |
| STORAGE_ENGINE_PORT | Startup |
| USE_TWO_PHASE_QUALIFICATION_SCHEME | Per-request when enabled |
| SKIP_E6_TRANSPILATION | Per-request when enabled |
| PRESERVE_FORMATTING | Per-request when enabled |

## Log format
Follows existing format: `%(asctime)s - TRANSPILER - %(levelname)s - %(message)s`

Startup example:
```
Environment flags — ENABLE_GUARDRAIL: False, SKIP_COMMENT: True, STORAGE_ENGINE_URL: localhost, STORAGE_ENGINE_PORT: 9005
```

Per-request example:
```
NO_ID_MENTIONED — SKIP_COMMENT: stripped comments
```

## Test plan
- [x] Verified logs appear in stdout when running converter_api.py locally