### PR TITLE
Fix '' quote escapes producing CONCAT in e6 output

### DIFF
--- a/converter_api.py
+++ b/converter_api.py
@@ -133,10 +133,6 @@ async def convert_query(
             query, comment = strip_comment(query)
             logger.info("%s — SKIP_COMMENT: stripped comments", query_id)
 
-        if FIX_QUOTE_ESCAPES.lower() == "true":
-            query = fix_quote_escapes(query)
-            logger.info("%s — FIX_QUOTE_ESCAPES: pre-processed quote escapes", query_id)
-
         tree = sqlglot.parse_one(query, read=from_sql, error_level=None)
 
         if flags_dict.get("USE_TWO_PHASE_QUALIFICATION_SCHEME", False):
@@ -169,10 +165,6 @@ async def convert_query(
         )
 
         double_quotes_added_query = replace_struct_in_query(double_quotes_added_query)
-
-        if FIX_QUOTE_ESCAPES.lower() == "true":
-            double_quotes_added_query = restore_quote_escapes(double_quotes_added_query)
-            logger.info("%s — FIX_QUOTE_ESCAPES: post-processed quote escapes", query_id)
 
         # Preserve original formatting if enabled via feature flag
         if flags_dict.get("PRESERVE_FORMATTING", False):

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -169,6 +169,85 @@ class Databricks(Spark):
             **Spark.Parser.FACTOR,
         }
 
+        def _parse_primary(self) -> t.Optional[exp.Expression]:
+            """
+            Override of the base parser's _parse_primary to handle consecutive
+            single-quoted string tokens when FIX_QUOTE_ESCAPES is enabled.
+
+            Problem:
+                In Databricks SQL, '' inside a string (e.g. 'ROCKIN'' AROUND')
+                is not treated as an escape sequence by the tokenizer (Hive-inherited
+                STRING_ESCAPES only has '\\'). So the tokenizer splits it into two
+                adjacent STRING tokens: 'ROCKIN' and ' AROUND'.
+
+                The base parser (parser.py:5807-5813) sees these adjacent STRING
+                tokens and wraps them in an exp.Concat node. The e6 generator then
+                outputs this as CONCAT('ROCKIN', ' AROUND'), which is incorrect.
+
+            Solution (gated behind FIX_QUOTE_ESCAPES env var):
+                Instead of creating a Concat, we merge consecutive single-quoted
+                STRING tokens back into a single exp.Literal, joining the parts
+                with '' (two single quotes). This preserves the original quote
+                structure as-is in the literal text:
+
+                Input:  'ROCKIN'' AROUND'   (2 adjacent STRING tokens)
+                Merged: Literal("ROCKIN'' AROUND") (1 literal, '' preserved)
+                Output: 'ROCKIN'' AROUND'   (passed through unchanged)
+
+                Input:  'Côte d''''Azur'    (3 adjacent STRING tokens)
+                Merged: Literal("Côte d''''Azur")  (1 literal, '''' preserved)
+                Output: 'Côte d''''Azur'    (passed through unchanged)
+
+            Note:
+                When FIX_QUOTE_ESCAPES is not enabled, falls back to base behavior
+                (adjacent strings become Concat). The rest of _parse_primary
+                (DOT+NUMBER, ODBC datetime, _parse_paren) is unchanged from base.
+            """
+            if os.getenv("FIX_QUOTE_ESCAPES", "False").lower() != "true":
+                return super()._parse_primary()
+
+            # Branch 1: Match against PRIMARY_PARSERS (handles STRING, NUMBER, etc.)
+            if self._match_set(self.PRIMARY_PARSERS):
+                token_type = self._prev.token_type
+                primary = self.PRIMARY_PARSERS[token_type](self, self._prev)
+
+                # Handle consecutive single-quoted STRING tokens:
+                # Merge them into one Literal with '' as separator instead of Concat
+                if token_type == TokenType.STRING:
+                    parts = [primary]
+                    while self._match(TokenType.STRING):
+                        parts.append(exp.Literal.string(self._prev.text))
+
+                    if len(parts) > 1:
+                        # Join with '' (two single quotes) to preserve the original
+                        # quote escaping as-is. The e6 generator's literal_sql is
+                        # overridden to output the text without re-escaping, so
+                        # '' passes through unchanged to the output.
+                        merged = "''".join(e.this for e in parts)
+                        return exp.Literal.string(merged)
+
+                return primary
+
+            # Branch 2: Handle .5 style decimal literals (DOT followed by NUMBER)
+            if self._match_pair(TokenType.DOT, TokenType.NUMBER):
+                return exp.Literal.number(f"0.{self._prev.text}")
+
+            # Branch 3: Check for ODBC datetime literals {d '...'}, {t '...'}, {ts '...'}
+            # Must match exact pattern: L_BRACE, VAR (d/t/ts), STRING, R_BRACE
+            if (
+                self._match(TokenType.L_BRACE, advance=False)
+                and self._next
+                and self._next.token_type == TokenType.VAR
+                and self._next.text.lower() in self.ODBC_DATETIME_LITERALS
+                and len(self._tokens) > self._index + 2
+                and self._tokens[self._index + 2].token_type == TokenType.STRING
+            ):
+                self._advance()  # consume L_BRACE
+                return self._parse_odbc_datetime_literal()
+
+            # Branch 4: Fallback to parsing parenthesized expressions
+            return self._parse_paren()
+
         def _parse_pivot_aggregation(self) -> t.Optional[exp.Expression]:
             """
             Override to support arbitrary expressions in PIVOT aggregation lists.

--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -1632,6 +1632,29 @@ class E6(Dialect):
         # But whenever we pass a normal query, by default parts like `NULLS LAST` etc were getting by defaults in order by clause which will differs the sequence of results displayed in original dialect and ours.
         # In order to tackle that, I overridden that so as to maintain structure of sqlglot with out altering original methods
 
+        def escape_str(self, text: str, escape_backslash: bool = True) -> str:
+            """
+            Override to skip re-escaping single quotes when FIX_QUOTE_ESCAPES
+            is enabled, while still handling backslash escaping.
+
+            The Databricks parser's _parse_primary merges adjacent single-quoted
+            string tokens (caused by '' escape patterns like ROCKIN'' or d'''')
+            into a single Literal with '' already in the text. We skip the
+            quote escaping step so '' passes through unchanged, but still
+            process ESCAPED_SEQUENCES for backslash handling (e.g. \\ -> \\\\).
+
+            When FIX_QUOTE_ESCAPES is not enabled, falls back to base behavior.
+            """
+            if os.getenv("FIX_QUOTE_ESCAPES", "False").lower() == "true":
+                if self.dialect.ESCAPED_SEQUENCES:
+                    to_escaped = self.dialect.ESCAPED_SEQUENCES
+                    text = "".join(
+                        to_escaped.get(ch, ch) if escape_backslash or ch != "\\" else ch
+                        for ch in text
+                    )
+                return self._replace_line_breaks(text)
+            return super().escape_str(text, escape_backslash)
+
         def pad_comment(self, comment: str) -> str:
             comment = comment.replace("/*", "/ *").replace("*/", "* /")
             comment = " " + comment if comment[0].strip() else comment

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -3504,3 +3504,45 @@ FROM dual"""
             ),
             "SELECT * FROM t PIVOT(SUM(x) AS x, TRY_DIVIDE(SUM(a), SUM(b)) * 100 AS pct FOR col IN ('A', 'B'))",
         )
+
+    def test_fix_quote_escapes(self):
+        """Test that '' escape patterns in Databricks are preserved in e6 output
+        without being converted to CONCAT, when FIX_QUOTE_ESCAPES is enabled."""
+        import sqlglot
+
+        os.environ["FIX_QUOTE_ESCAPES"] = "True"
+
+        def transpile(sql):
+            return sqlglot.transpile(sql, read="databricks", write="e6", from_dialect="databricks")[
+                0
+            ]
+
+        # 1. Simple '' escape
+        self.assertEqual(
+            transpile("SELECT 'ROCKIN'' AROUND THE CHRISTMAS TREE' AS title"),
+            "SELECT 'ROCKIN'' AROUND THE CHRISTMAS TREE' AS title",
+        )
+
+        # 2. Four quotes ('''')
+        self.assertEqual(
+            transpile("SELECT 'Côte d''''Azur' AS region"),
+            "SELECT 'Côte d''''Azur' AS region",
+        )
+
+        # 3. Large INSERT with d''''Azur and d''album
+        self.assertEqual(
+            transpile(
+                r"""INSERT INTO espresso_gold_prod.global.my_reports (report_id, report_name, report_parameter, user_id, email_id, category_id, created_date, status_id, country_id, audio_video_flag, selection_object, frequency_id, custom_report_yn, selection_summary) SELECT uuid(), 'MARKET SHARE_260416100118', '{"moduleName":"Market","tabName":"Market Share","scenario":"label","countryId":"3","mediaType":"audio","languageCode":"fr","data":[{"field":"breakdown_column","name":"Provence-Alpes-Côte d''''Azur,France","id":null,"display":"Breakdown Column","operatorUsed":""}]}', '1', 'payel.masanta@kantar.com', 5, CURRENT_TIMESTAMP, '1', '3', 'Audio', '{"test":"data"}', '1', 'Y', 'Time Period 1: Hebdomadaire 2601 - 2615 | Album Type: Tous types d''album | Display Units: Unites*'"""
+            ),
+            """INSERT INTO espresso_gold_prod.global.my_reports (report_id, report_name, report_parameter, user_id, email_id, category_id, created_date, status_id, country_id, audio_video_flag, selection_object, frequency_id, custom_report_yn, selection_summary) SELECT UUID(), 'MARKET SHARE_260416100118', '{"moduleName":"Market","tabName":"Market Share","scenario":"label","countryId":"3","mediaType":"audio","languageCode":"fr","data":[{"field":"breakdown_column","name":"Provence-Alpes-Côte d''''Azur,France","id":null,"display":"Breakdown Column","operatorUsed":""}]}', '1', 'payel.masanta@kantar.com', 5, CURRENT_TIMESTAMP, '1', '3', 'Audio', '{"test":"data"}', '1', 'Y', 'Time Period 1: Hebdomadaire 2601 - 2615 | Album Type: Tous types d''album | Display Units: Unites*'""",
+        )
+
+        # 4. Large INSERT with multiple '' patterns in JSON data
+        self.assertEqual(
+            transpile(
+                """INSERT INTO espresso_gold_test.e6data_test.story_items_dml_clone (story_item_id, story_id, item_data) SELECT uuid(), '54e04514-5aad-4e24-9189-2b369970e70b', '[{"Title":"ROCKIN'' AROUND THE CHRISTMAS TREE","Artist":"BRENDA LEE"},{"Title":"SHAKIN'' STEVENS"},{"Title":"DO THEY KNOW IT''S CHRISTMAS"},{"Title":"IT''S THE MOST WONDERFUL TIME"},{"Title":"SANTA CAN''T YOU HEAR ME"},{"Title":"NOBODY''S GIRL"},{"Title":"SANTA CLAUS IS COMIN'' TO TOWN"},{"Title":"DON''T CALL"},{"Title":"NOBODY''S SON"}]'"""
+            ),
+            """INSERT INTO espresso_gold_test.e6data_test.story_items_dml_clone (story_item_id, story_id, item_data) SELECT UUID(), '54e04514-5aad-4e24-9189-2b369970e70b', '[{"Title":"ROCKIN'' AROUND THE CHRISTMAS TREE","Artist":"BRENDA LEE"},{"Title":"SHAKIN'' STEVENS"},{"Title":"DO THEY KNOW IT''S CHRISTMAS"},{"Title":"IT''S THE MOST WONDERFUL TIME"},{"Title":"SANTA CAN''T YOU HEAR ME"},{"Title":"NOBODY''S GIRL"},{"Title":"SANTA CLAUS IS COMIN'' TO TOWN"},{"Title":"DON''T CALL"},{"Title":"NOBODY''S SON"}]'""",
+        )
+
+        os.environ["FIX_QUOTE_ESCAPES"] = "False"


### PR DESCRIPTION
## Summary
- When `FIX_QUOTE_ESCAPES` is enabled, adjacent single-quoted string tokens caused by `''` escape patterns (e.g. `ROCKIN'' AROUND`, `d''''Azur`) are now merged into a single `Literal` in the Databricks parser instead of being wrapped in a `Concat` node
- The e6 generator's `escape_str` is overridden to skip re-escaping single quotes (while preserving backslash escaping) so `''` passes through unchanged to the output
- Removed the old regex-based `fix_quote_escapes`/`restore_quote_escapes` pre/post-processing in `converter_api.py` as it is superseded by the parser-level fix

## Changes
- **`sqlglot/dialects/databricks.py`**: Override `_parse_primary` to merge consecutive single-quoted STRING tokens into one Literal with `''` as separator (gated behind `FIX_QUOTE_ESCAPES` env var)
- **`sqlglot/dialects/e6.py`**: Override `escape_str` to skip quote re-escaping when `FIX_QUOTE_ESCAPES` is enabled, while still handling backslash escaping
- **`converter_api.py`**: Remove `fix_quote_escapes()`/`restore_quote_escapes()` calls from the `/convert-query` endpoint

## Test plan
- [ ] Run `make test` — all 1010 tests pass (including `test_split_sql` backslash escaping)
- [ ] Set `FIX_QUOTE_ESCAPES=True` and verify:
  - `'ROCKIN'' AROUND'` → `'ROCKIN'' AROUND'` (no CONCAT, quotes preserved)
  - `'Côte d''''Azur'` → `'Côte d''''Azur'` (no CONCAT, 4 quotes preserved)
  - Large INSERT with 13+ `''` patterns → all preserved, zero CONCAT
- [ ] Set `FIX_QUOTE_ESCAPES=False` and verify old behavior (CONCAT) is unchanged