### PR TITLE
fix(e6): preserve DBR DATE_ADD arity under E6_EXECUTOR_TYPE=native

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -135,8 +135,11 @@ class Databricks(Spark):
         FUNCTIONS = {
             **Spark.Parser.FUNCTIONS,
             "MAKE_INTERVAL": _build_make_interval,
-            "DATEADD": build_date_delta(exp.DateAdd),
-            "DATE_ADD": build_date_delta(exp.DateAdd),
+            # default_unit=None preserves the 2-arg vs 3-arg distinction:
+            # 2-arg DATE_ADD(date, n) -> unit=None (returns DATE in DBR);
+            # 3-arg DATE_ADD(unit, n, ts) -> unit=Var(unit) (returns TIMESTAMP).
+            "DATEADD": build_date_delta(exp.DateAdd, default_unit=None),
+            "DATE_ADD": build_date_delta(exp.DateAdd, default_unit=None),
             "DATEDIFF": build_date_delta(exp.DateDiff),
             "DATE_DIFF": build_date_delta(exp.DateDiff),
             "FIND_IN_SET": exp.FindInSet.from_arg_list,

--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -1466,7 +1466,9 @@ class E6(Dialect):
             "CURRENT_TIMESTAMP": exp.CurrentTimestamp.from_arg_list,
             "DATE": _build_date,
             "DATE_ADD": lambda args: exp.DateAdd(
-                this=seq_get(args, 2), expression=seq_get(args, 1), unit=seq_get(args, 0)
+                this=seq_get(args, 0) if len(args) == 2 else seq_get(args, 2),
+                expression=seq_get(args, 1),
+                unit=exp.Literal.string("DAY") if len(args) == 2 else seq_get(args, 0),
             ),
             "DATE_DIFF": build_datediff(exp.DateDiff),
             "DATEDIFF": build_datediff(exp.DateDiff),
@@ -2619,6 +2621,23 @@ class E6(Dialect):
             else:
                 return self.func("TO_DATE", expression.this, add_single_quotes(format_str))
 
+        def dateadd_sql(self, expression: exp.DateAdd) -> str:
+            # On native executor, preserve the DBR source arity: 2-arg
+            # DATE_ADD(date, n) (unit=None after parse) returns DATE in DBR,
+            # so emit e6's 2-arg form to keep that return type. 3-arg input
+            # keeps an explicit unit and stays 3-arg.
+            # On java executor (default), always emit 3-arg with DAY filled in
+            # for the 2-arg case — unchanged from prior behavior.
+            unit = expression.args.get("unit")
+            is_native = os.getenv("E6_EXECUTOR_TYPE", "java").lower() == "native"
+
+            if is_native and unit is None:
+                return self.func("DATE_ADD", expression.this, _to_int(expression.expression))
+
+            return self.func(
+                "DATE_ADD", unit_to_str(expression), _to_int(expression.expression), expression.this
+            )
+
         def to_unix_timestamp_sql(
             self: E6.Generator, expression: exp.TimeToUnix | exp.StrToUnix
         ) -> str:
@@ -2987,12 +3006,6 @@ class E6(Dialect):
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
             exp.Coalesce: coalesce_sql,
             exp.Date: lambda self, e: self.func("DATE", e.this),
-            exp.DateAdd: lambda self, e: self.func(
-                "DATE_ADD",
-                unit_to_str(e),
-                _to_int(e.expression),
-                e.this,
-            ),
             # follows signature DATE_DIFF([ <unit>,] <date_expr1>, <date_expr2>) of E6. => date_expr1 - date_expr2, so interchanging the second and third arg
             exp.DateDiff: date_diff_sql,  # lambda self, e: self.func("DATEDIFF", e.this, e.expression, unit_to_str(e)),
             exp.DateSub: rename_func("DATE_SUB"),

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -2059,6 +2059,13 @@ class TestE6(Validator):
             read={"databricks": "select date_add('year', 5, cast('2000-08-05' as date))"},
         )
 
+        # Java default: 2-arg DBR DATE_ADD always converts to 3-arg with DAY filled in
+        # (preserves prior behavior).
+        self.validate_all(
+            "SELECT DATE_ADD('DAY', 2, CURRENT_TIMESTAMP)",
+            read={"databricks": "SELECT DATE_ADD(CURRENT_TIMESTAMP, 2)"},
+        )
+
         self.validate_all(
             "SELECT DATE_DIFF('2022-03-28', '2021-01-01', 'YEAR')",
             read={"databricks": """SELECT date_diff("YEAR", '2021-01-01', '2022-03-28')"""},
@@ -2475,6 +2482,34 @@ class TestE6(Validator):
         self.validate_all(
             "SELECT TO_UNIX_TIMESTAMP(CAST(A AS TIMESTAMP)) / 1000",
             read={"databricks": "SELECT UNIX_TIMESTAMP(A)"},
+        )
+
+    def test_date_add_native_executor(self):
+        # With E6_EXECUTOR_TYPE=native, preserve DBR DATE_ADD arity:
+        # 2-arg DATE_ADD(date, n) returns DATE -> emit e6 2-arg form;
+        # 3-arg DATE_ADD(unit, n, ts) returns TIMESTAMP -> emit e6 3-arg form.
+        # Default (java) collapses both to 3-arg, matching prior behavior.
+        os.environ["E6_EXECUTOR_TYPE"] = "native"
+        try:
+            self.validate_all(
+                "SELECT DATE_ADD(CURRENT_TIMESTAMP, 2)",
+                read={"databricks": "SELECT DATE_ADD(CURRENT_TIMESTAMP, 2)"},
+            )
+            self.validate_all(
+                "SELECT DATE_ADD(CURRENT_TIMESTAMP, 2)",
+                read={"databricks": "SELECT DATEADD(CURRENT_TIMESTAMP, 2)"},
+            )
+            self.validate_all(
+                "SELECT DATE_ADD('DAY', 2, CURRENT_TIMESTAMP)",
+                read={"databricks": "SELECT DATE_ADD('DAY', 2, CURRENT_TIMESTAMP)"},
+            )
+        finally:
+            os.environ.pop("E6_EXECUTOR_TYPE", None)
+
+        # Default (java): 2-arg DBR converts to 3-arg with DAY filled in
+        self.validate_all(
+            "SELECT DATE_ADD('DAY', 2, CURRENT_TIMESTAMP)",
+            read={"databricks": "SELECT DATE_ADD(CURRENT_TIMESTAMP, 2)"},
         )
 
     def test_timestamp_seconds(self):


### PR DESCRIPTION
## Summary
- Databricks 2-arg `DATE_ADD(date, n)` returns DATE; 3-arg `DATE_ADD(unit, n, ts)` returns TIMESTAMP. The transpiler previously collapsed both to e6 3-arg `DATE_ADD('DAY', n, ts)`, switching the return type and breaking `CONCAT(DATE_ADD(ts, 0), SUBSTR(ts, 11))` patterns by producing a doubled time portion (Samsung zero-row issue).
- New behavior is gated behind `E6_EXECUTOR_TYPE=native` (the same flag used by PR #253). Java executor default is unchanged.
  - **`E6_EXECUTOR_TYPE=native`**: 2-arg DBR -> e6 2-arg `DATE_ADD(ts, n)`; 3-arg DBR -> e6 3-arg `DATE_ADD(unit, n, ts)`.
  - **default (`java`)**: 2-arg and 3-arg DBR both emit e6 3-arg with `DAY` filled in (prior behavior preserved).
- Non-DAY units (e.g. `DATE_ADD('YEAR', 5, d)`) always stay 3-arg in both modes.

## Mechanism
- `sqlglot/dialects/databricks.py`: pass `default_unit=None` to `build_date_delta` for `DATE_ADD`/`DATEADD`. Now 2-arg DBR parses with `unit=None`, 3-arg with an explicit unit. Matches the pattern at `clickhouse.py:310`. No DBR output change since `date_delta_sql` falls back to `DAY` via `unit_to_var`.
- `sqlglot/dialects/e6.py`: new auto-discovered `dateadd_sql` method reads `E6_EXECUTOR_TYPE` and emits 2-arg only when native AND `unit is None`. Replaces the previous `exp.DateAdd: lambda` TRANSFORMS entry. Read parser also handles 2-arg `DATE_ADD(date, n)` for round-trips.

## Context
The Samsung repro pattern:
```sql
CONCAT(
  DATE_ADD(CAST(... AS TIMESTAMP), CAST(7 * 0 AS INT)),
  SUBSTR(<ts>, 11)
)
```
With prior 3-arg conversion, `DATE_ADD` returned TIMESTAMP -> `CONCAT(<full ts>, ' 00:00:00')` -> doubled time portion -> invalid timestamp -> NULL after outer `CAST`, predicate becomes unknown, rows dropped.

## Test plan
- [x] New `test_date_add_native_executor` covering both modes (2-arg/3-arg input, 2-arg/3-arg expected output).
- [x] Existing `test_dialect_specific_functions` extended with the java-default case (`DATE_ADD(ts, 2)` -> `DATE_ADD('DAY', 2, ts)`).
- [x] `python -m unittest discover tests/dialects` -> 545/545 pass (e6, databricks, spark, hive, etc.) -- no regressions.