### PR TITLE
fix(e6): escape lone apostrophes in literals under FIX_QUOTE_ESCAPES

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -1648,6 +1648,8 @@ class E6(Dialect):
             When FIX_QUOTE_ESCAPES is not enabled, falls back to base behavior.
             """
             if os.getenv("FIX_QUOTE_ESCAPES", "False").lower() == "true":
+                if "''" not in text:
+                    return super().escape_str(text, escape_backslash)
                 if self.dialect.ESCAPED_SEQUENCES:
                     to_escaped = self.dialect.ESCAPED_SEQUENCES
                     text = "".join(

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -3636,13 +3636,13 @@ FROM dual"""
             """INSERT INTO espresso_gold_test.e6data_test.story_items_dml_clone (story_item_id, story_id, item_data) SELECT UUID(), '54e04514-5aad-4e24-9189-2b369970e70b', '[{"Title":"ROCKIN'' AROUND THE CHRISTMAS TREE","Artist":"BRENDA LEE"},{"Title":"SHAKIN'' STEVENS"},{"Title":"DO THEY KNOW IT''S CHRISTMAS"},{"Title":"IT''S THE MOST WONDERFUL TIME"},{"Title":"SANTA CAN''T YOU HEAR ME"},{"Title":"NOBODY''S GIRL"},{"Title":"SANTA CLAUS IS COMIN'' TO TOWN"},{"Title":"DON''T CALL"},{"Title":"NOBODY''S SON"}]'""",
         )
 
-        # 5. Databricks double-quoted string with apostrophe inside (Kantar variant A)
+        # 5. Databricks double-quoted string with apostrophe inside (variant A)
         self.assertEqual(
             transpile("""SELECT "SCARLET'S WALK (2023 REMASTER)" AS name"""),
             r"""SELECT 'SCARLET\'S WALK (2023 REMASTER)' AS name""",
         )
 
-        # 6. Full Kantar INSERT — double-quoted string with apostrophe in map() value
+        # 6. Full INSERT — double-quoted string with apostrophe in map() value
         self.assertEqual(
             transpile(
                 """INSERT INTO espresso_gold_prod.global.ui_my_fav_charts_main (selection, module_name) VALUES (map('product_id', '51605207', 'name', "SCARLET'S WALK (2023 REMASTER)", 'class_dbid', ''), 'Product-Summary')"""

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -3636,4 +3636,18 @@ FROM dual"""
             """INSERT INTO espresso_gold_test.e6data_test.story_items_dml_clone (story_item_id, story_id, item_data) SELECT UUID(), '54e04514-5aad-4e24-9189-2b369970e70b', '[{"Title":"ROCKIN'' AROUND THE CHRISTMAS TREE","Artist":"BRENDA LEE"},{"Title":"SHAKIN'' STEVENS"},{"Title":"DO THEY KNOW IT''S CHRISTMAS"},{"Title":"IT''S THE MOST WONDERFUL TIME"},{"Title":"SANTA CAN''T YOU HEAR ME"},{"Title":"NOBODY''S GIRL"},{"Title":"SANTA CLAUS IS COMIN'' TO TOWN"},{"Title":"DON''T CALL"},{"Title":"NOBODY''S SON"}]'""",
         )
 
+        # 5. Databricks double-quoted string with apostrophe inside (Kantar variant A)
+        self.assertEqual(
+            transpile("""SELECT "SCARLET'S WALK (2023 REMASTER)" AS name"""),
+            r"""SELECT 'SCARLET\'S WALK (2023 REMASTER)' AS name""",
+        )
+
+        # 6. Full Kantar INSERT — double-quoted string with apostrophe in map() value
+        self.assertEqual(
+            transpile(
+                """INSERT INTO espresso_gold_prod.global.ui_my_fav_charts_main (selection, module_name) VALUES (map('product_id', '51605207', 'name', "SCARLET'S WALK (2023 REMASTER)", 'class_dbid', ''), 'Product-Summary')"""
+            ),
+            r"""INSERT INTO espresso_gold_prod.global.ui_my_fav_charts_main (selection, module_name) VALUES (map('product_id', '51605207', 'name', 'SCARLET\'S WALK (2023 REMASTER)', 'class_dbid', ''), 'Product-Summary')""",
+        )
+
         os.environ["FIX_QUOTE_ESCAPES"] = "False"


### PR DESCRIPTION
## Summary

Kantar's INSERT queries containing Databricks double-quoted strings with an apostrophe inside — e.g. `"SCARLET'S WALK (2023 REMASTER)"` — were emitting invalid E6 with the apostrophe unescaped. The bare `'` terminated the output string literal early.

The E6 generator's `escape_str` override at `sqlglot/dialects/e6.py` unconditionally skipped the single-quote escape pass under `FIX_QUOTE_ESCAPES=true`. That is correct only for Variant C literals (parser-merged adjacent string tokens with `''` embedded in `Literal.this`). For literals whose text contains a lone `'` (Databricks `"..."` strings, or `\'` escapes the tokenizer consumed), the override produced raw apostrophes in output.

## Fix

Gate the override on whether `''` is actually present in the literal text. When `''` is not in the text, defer to the base `Generator.escape_str`, which correctly replaces `'` with `\'` since E6's `STRING_ESCAPES = ['\\']`. When `''` is present, retain the existing behavior — `''` passes through unchanged, no `\'` introduced.

```python
if os.getenv("FIX_QUOTE_ESCAPES", "False").lower() == "true":
    if "''" not in text:
        return super().escape_str(text, escape_backslash)
    # ... existing override body
```

## Behavior

| Input | Literal.this | Path | Output |
|---|---|---|---|
| `"SCARLET'S WALK"` (Kantar) | `SCARLET'S WALK` | base | `'SCARLET\'S WALK'` |
| `'ROCKIN'' AROUND'` | `ROCKIN'' AROUND` | override (unchanged) | `'ROCKIN'' AROUND'` |
| `'Côte d''''Azur'` | `Côte d''''Azur` | override (unchanged) | `'Côte d''''Azur'` |

## Test plan

- [x] Existing `test_fix_quote_escapes` continues to pass (4 cases — all literals contain `''`, take the unchanged path).
- [x] Two new cases added: Databricks double-quoted string with apostrophe inside, and the full Kantar INSERT shape.
- [x] Full E6 dialect test suite: 50/50 pass.
- [x] Verified end-to-end against the running converter API with `FIX_QUOTE_ESCAPES=true` on Kantar's exact query.