### PR TITLE
fix(e6): emit Dot(Literal, Literal) projections as quoted identifiers

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -2454,6 +2454,41 @@ class E6(Dialect):
 
             return self.func(function_name, *expression.expressions, normalize=not is_qualified)
 
+        def dot_sql(self, expression: exp.Dot) -> str:
+            # Databricks (default) lexes `"X"` as a string, so a producer that
+            # wrote `"$Table"."col"` as an ANSI-style column reference ends up
+            # with Dot(Literal('$Table'), Literal('col')) and would round-trip
+            # as `'$Table'.'col'`. When the Dot sits as a SELECT projection
+            # (directly or wrapped in an Alias), rebuild it as a Column with
+            # quoted Identifier qualifiers so the e6 generator emits proper
+            # "X"."Y". Other positions (CONCAT args, struct paths, WHERE
+            # values, etc.) fall through to the default Dot rendering.
+            parent = expression.parent
+            grandparent = parent.parent if isinstance(parent, exp.Alias) else None
+            in_select_projection = isinstance(parent, exp.Select) or isinstance(
+                grandparent, exp.Select
+            )
+
+            if in_select_projection:
+                left = expression.args.get("this")
+                right = expression.args.get("expression")
+                left_is_str_lit = isinstance(left, exp.Literal) and left.is_string
+                right_is_str_lit = isinstance(right, exp.Literal) and right.is_string
+                if left_is_str_lit or right_is_str_lit:
+                    table = (
+                        exp.to_identifier(left.name, quoted=True)
+                        if isinstance(left, exp.Literal) and left.is_string
+                        else left
+                    )
+                    column = (
+                        exp.to_identifier(right.name, quoted=True)
+                        if isinstance(right, exp.Literal) and right.is_string
+                        else right
+                    )
+                    return self.sql(exp.Column(this=column, table=table))
+
+            return super().dot_sql(expression)
+
         def to_timestamp_sql(self: E6.Generator, expression: exp.StrToTime) -> str:
             date_expr = expression.this
             format_expr = self.convert_format_time(expression)

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -3251,6 +3251,59 @@ class TestE6(Validator):
             },
         )
 
+    def test_databricks_double_quoted_dot_projection(self):
+        """In Databricks (default) `"X"` lexes as a string, so `"X"."Y"` parses
+        as Dot(Literal, Literal). When such a Dot is used as a SELECT projection
+        (a common pattern from BI tools that emit ANSI-style quoting wrapped as
+        Databricks SQL), the e6 generator should re-emit the operands as quoted
+        identifiers — not as single-quoted string literals.
+
+        Other positions (function arguments like CONCAT) and other source
+        dialects (snowflake, e6) are untouched.
+        """
+        # Bare Dot projection: "$Table"."col" from Databricks must become "$Table"."col"
+        self.validate_all(
+            'SELECT "$Table"."col" FROM t',
+            read={
+                "databricks": 'SELECT "$Table"."col" FROM t',
+            },
+        )
+
+        # Aliased Dot projection: AS "alias" must also round-trip with both sides quoted
+        self.validate_all(
+            'SELECT "$Table"."col" AS "col_alias" FROM t',
+            read={
+                "databricks": 'SELECT "$Table"."col" AS "col_alias" FROM t',
+            },
+        )
+
+        # Multiple projections in one query (mirrors the real BI-tool shape)
+        self.validate_all(
+            'SELECT "$Table"."a" AS "a", "$Table"."b" AS "b" FROM t',
+            read={
+                "databricks": 'SELECT "$Table"."a" AS "a", "$Table"."b" AS "b" FROM t',
+            },
+        )
+
+        # Regression: CONCAT("x", "y") in Databricks must still emit string
+        # literals, not identifiers. The Literals here are function arguments,
+        # not Dot operands — the override must leave them alone.
+        self.validate_all(
+            "SELECT CONCAT('hello', 'world') AS greeting FROM t",
+            read={
+                "databricks": 'SELECT CONCAT("hello", "world") AS greeting FROM t',
+            },
+        )
+
+        # Regression: Snowflake source already parses `"X"."Y"` as identifiers,
+        # so the override must not double-handle it.
+        self.validate_all(
+            'SELECT "$Table"."col" FROM t',
+            read={
+                "snowflake": 'SELECT "$Table"."col" FROM t',
+            },
+        )
+
     def test_cast_precision_preserved(self):
         """Test that CAST preserves precision/scale for DECIMAL and other types.
 


### PR DESCRIPTION
## Summary

- Databricks (default) lexes `"X"` as a string literal, so an ANSI-style column reference like `"$Table"."col"` parses as `Dot(Literal('$Table'), Literal('col'))` and round-trips out as `'$Table'.'col'` — semantically wrong for BI-tool queries that emit double-quoted identifiers but tag the dialect as Databricks.
- Add a narrow `dot_sql` override on the e6 generator that only fires when the `Dot` sits as a SELECT projection (directly or wrapped in an `Alias`) and either operand is a string `Literal`. In that case it rebuilds the node as `exp.Column` with quoted `Identifier` qualifiers and delegates to `self.sql`.
- All other positions fall through to `super().dot_sql`. `CONCAT("a", "b")` still emits `CONCAT('a', 'b')`; struct paths, `WHERE` values, function args, `GROUP BY` etc. are untouched; other source dialects (snowflake, e6) are unaffected.

## Before

```sql
-- input (Databricks)
SELECT "$Table"."controlAttributeID" AS "controlAttributeID" FROM t

-- e6 output
SELECT '$Table'.'controlAttributeID' AS "controlAttributeID" FROM t   -- BROKEN
```

## After

```sql
SELECT "$Table"."controlAttributeID" AS "controlAttributeID" FROM t   -- correct
```

## Test plan

- [x] New e6 test `test_databricks_double_quoted_dot_projection` covers:
  - bare `"X"."Y"` projection
  - aliased `"X"."Y" AS "z"` projection
  - multiple projections in one SELECT
  - regression: `CONCAT("a","b")` stays as `CONCAT('a','b')`
  - regression: Snowflake source still parses `"X"."Y"` as identifiers and round-trips cleanly
- [x] `make check` clean (ruff, ruff-format, mypy; full 1018-test suite passes)