### PR TITLE
fix(e6): handle nested Dot chains like "schema"."table"."col"

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -2455,39 +2455,45 @@ class E6(Dialect):
             return self.func(function_name, *expression.expressions, normalize=not is_qualified)
 
         def dot_sql(self, expression: exp.Dot) -> str:
-            # Databricks (default) lexes `"X"` as a string, so a producer that
-            # wrote `"$Table"."col"` as an ANSI-style column reference ends up
-            # with Dot(Literal('$Table'), Literal('col')) and would round-trip
-            # as `'$Table'.'col'`. When the Dot sits as a SELECT projection
-            # (directly or wrapped in an Alias), rebuild it as a Column with
-            # quoted Identifier qualifiers so the e6 generator emits proper
-            # "X"."Y". Other positions (CONCAT args, struct paths, WHERE
-            # values, etc.) fall through to the default Dot rendering.
-            parent = expression.parent
-            grandparent = parent.parent if isinstance(parent, exp.Alias) else None
-            in_select_projection = isinstance(parent, exp.Select) or isinstance(
-                grandparent, exp.Select
-            )
+            # In Databricks (default), `"X"` lexes as a string Literal, so an
+            # ANSI-style column reference such as `"$Table"."col"` or
+            # `"schema"."table"."col"` parses as a (possibly nested) Dot whose
+            # operands are string Literals. Round-tripping that through the
+            # default generator emits `'$Table'.'col'` / `'schema'.'table'.'col'`
+            # which the e6 planner won't accept as a column reference.
+            #
+            # When a Dot's chain contains string Literals, recursively rebuild
+            # the chain with each Literal coerced to a quoted Identifier, then
+            # delegate to super for rendering. CONCAT args and other non-Dot
+            # positions are untouched — they are not Dot operands. Other source
+            # dialects (snowflake, e6) parse `"X"` as Identifier already, so
+            # this path is a no-op for them.
+            left = expression.args.get("this")
+            right = expression.args.get("expression")
 
-            if in_select_projection:
-                left = expression.args.get("this")
-                right = expression.args.get("expression")
-                left_is_str_lit = isinstance(left, exp.Literal) and left.is_string
-                right_is_str_lit = isinstance(right, exp.Literal) and right.is_string
-                if left_is_str_lit or right_is_str_lit:
-                    table = (
-                        exp.to_identifier(left.name, quoted=True)
-                        if isinstance(left, exp.Literal) and left.is_string
-                        else left
+            def _has_string_literal(node: t.Optional[exp.Expression]) -> bool:
+                if isinstance(node, exp.Literal) and node.is_string:
+                    return True
+                if isinstance(node, exp.Dot):
+                    return _has_string_literal(node.args.get("this")) or _has_string_literal(
+                        node.args.get("expression")
                     )
-                    column = (
-                        exp.to_identifier(right.name, quoted=True)
-                        if isinstance(right, exp.Literal) and right.is_string
-                        else right
-                    )
-                    return self.sql(exp.Column(this=column, table=table))
+                return False
 
-            return super().dot_sql(expression)
+            if not (_has_string_literal(left) or _has_string_literal(right)):
+                return super().dot_sql(expression)
+
+            def _coerce(node: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
+                if isinstance(node, exp.Literal) and node.is_string:
+                    return exp.to_identifier(node.name, quoted=True)
+                if isinstance(node, exp.Dot):
+                    return exp.Dot(
+                        this=_coerce(node.args.get("this")),
+                        expression=_coerce(node.args.get("expression")),
+                    )
+                return node.copy() if node is not None else node
+
+            return super().dot_sql(exp.Dot(this=_coerce(left), expression=_coerce(right)))
 
         def to_timestamp_sql(self: E6.Generator, expression: exp.StrToTime) -> str:
             date_expr = expression.this

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -3252,16 +3252,16 @@ class TestE6(Validator):
         )
 
     def test_databricks_double_quoted_dot_projection(self):
-        """In Databricks (default) `"X"` lexes as a string, so `"X"."Y"` parses
-        as Dot(Literal, Literal). When such a Dot is used as a SELECT projection
-        (a common pattern from BI tools that emit ANSI-style quoting wrapped as
-        Databricks SQL), the e6 generator should re-emit the operands as quoted
-        identifiers — not as single-quoted string literals.
+        """In Databricks (default) `"X"` lexes as a string, so `"X"."Y"`
+        (and longer chains like `"schema"."table"."col"`) parse as Dot of
+        string Literals. The e6 generator should re-emit those operands as
+        quoted identifiers wherever the chain appears as a column reference
+        — SELECT projection, WHERE, ORDER BY — not as single-quoted strings.
 
-        Other positions (function arguments like CONCAT) and other source
-        dialects (snowflake, e6) are untouched.
+        Function arguments (CONCAT, etc.) and other source dialects
+        (snowflake, e6) are untouched.
         """
-        # Bare Dot projection: "$Table"."col" from Databricks must become "$Table"."col"
+        # 2-part: bare projection
         self.validate_all(
             'SELECT "$Table"."col" FROM t',
             read={
@@ -3269,7 +3269,7 @@ class TestE6(Validator):
             },
         )
 
-        # Aliased Dot projection: AS "alias" must also round-trip with both sides quoted
+        # 2-part: aliased projection
         self.validate_all(
             'SELECT "$Table"."col" AS "col_alias" FROM t',
             read={
@@ -3277,11 +3277,43 @@ class TestE6(Validator):
             },
         )
 
-        # Multiple projections in one query (mirrors the real BI-tool shape)
+        # 2-part: multiple projections in one query
         self.validate_all(
             'SELECT "$Table"."a" AS "a", "$Table"."b" AS "b" FROM t',
             read={
                 "databricks": 'SELECT "$Table"."a" AS "a", "$Table"."b" AS "b" FROM t',
+            },
+        )
+
+        # 3-part: nested Dot chain in projection
+        self.validate_all(
+            'SELECT "schema"."table"."col" FROM t',
+            read={
+                "databricks": 'SELECT "schema"."table"."col" FROM t',
+            },
+        )
+
+        # 3-part: aliased
+        self.validate_all(
+            'SELECT "schema"."table"."col" AS "aliased" FROM t',
+            read={
+                "databricks": 'SELECT "schema"."table"."col" AS "aliased" FROM t',
+            },
+        )
+
+        # 3-part: WHERE clause column reference
+        self.validate_all(
+            'SELECT * FROM t WHERE "schema"."table"."col" = 1',
+            read={
+                "databricks": 'SELECT * FROM t WHERE "schema"."table"."col" = 1',
+            },
+        )
+
+        # 3-part: ORDER BY column reference
+        self.validate_all(
+            'SELECT * FROM t ORDER BY "schema"."table"."col"',
+            read={
+                "databricks": 'SELECT * FROM t ORDER BY "schema"."table"."col"',
             },
         )
 


### PR DESCRIPTION
## Summary

Follow-up to #257. The previous PR handled 2-part `Dot(Literal, Literal)` projections coming from Databricks-tagged ANSI SQL (e.g. `"$Table"."col"`). 3-part chains like `"schema"."table"."col"` parse as nested `Dot(Dot(Literal, Literal), Literal)` and the inner Dot still fell through to the default generator, so the chain round-tripped as `'schema'.'table'.'col'`.

This PR makes the `dot_sql` override recursive: when any operand in a Dot chain is a string Literal, the chain is rebuilt with each Literal coerced to a quoted `Identifier` and then handed off to `super().dot_sql` for rendering. Chains that already contain `Identifier`s (Snowflake source, struct paths with bare names, normal column references, etc.) hit a fast-path and are unchanged.

The e6 planner has been verified to accept the fully-quoted 3-part form in SELECT, WHERE, and ORDER BY positions, so the override now fires anywhere the Dot chain appears as a column reference.

## Before

```sql
-- input (Databricks)
SELECT "schema"."table"."col" FROM t
SELECT * FROM t WHERE "schema"."table"."col" = 1

-- e6 output
SELECT 'schema'.'table'."col" FROM t                 -- BROKEN (inner Dot fell through)
SELECT * FROM t WHERE 'schema'.'table'.'col' = 1     -- BROKEN
```

## After

```sql
SELECT "schema"."table"."col" FROM t                 -- correct
SELECT * FROM t WHERE "schema"."table"."col" = 1     -- correct
SELECT * FROM t ORDER BY "schema"."table"."col"      -- correct
```

## Test plan

- [x] `test_databricks_double_quoted_dot_projection` extended to 9 sub-cases:
  - 2-part bare projection, aliased projection, multi-projection (existing)
  - 3-part bare projection
  - 3-part aliased projection
  - 3-part in WHERE
  - 3-part in ORDER BY
  - Regression: `CONCAT("a","b")` still emits `CONCAT('a','b')`
  - Regression: Snowflake source `"X"."Y"` still parses as Identifiers
- [x] `make check` clean (ruff, ruff-format, mypy, 1018-test suite)