### PR TITLE
feat(api): POWERBI_SF_TO_DBR feature flag for /convert-query

### DIFF
--- a/converter_api.py
+++ b/converter_api.py
@@ -104,6 +104,28 @@ async def convert_query(
         except json.JSONDecodeError as je:
             return HTTPException(status_code=500, detail=str(je))
 
+    if flags_dict.get("POWERBI_SF_TO_DBR", False):
+        # Intermediary vanilla Snowflake -> Databricks transpile. The result is
+        # then handed back to the normal pipeline below (parse + e6 transforms +
+        # generator) using the caller's `from_sql` and `to_sql` unchanged.
+        logger.info(
+            "%s AT %s — POWERBI_SF_TO_DBR: intermediary Snowflake -> Databricks transpile",
+            query_id,
+            timestamp,
+        )
+        query = sqlglot.transpile(
+            query,
+            read="snowflake",
+            write="databricks",
+            identify=False,
+        )[0]
+        logger.info(
+            "%s AT %s — Intermediary (SF -> DBR) result:\n%s",
+            query_id,
+            timestamp,
+            query,
+        )
+
     if not query or not query.strip():
         logger.info(
             "%s AT %s FROM %s — Empty query received, returning empty result",


### PR DESCRIPTION
## Summary

Adds an opt-in feature flag `POWERBI_SF_TO_DBR` to the `/convert-query` endpoint. When enabled, the input query is first transpiled vanilla **Snowflake → Databricks** via `sqlglot.transpile(..., read='snowflake', write='databricks', identify=False)`, and the result is then handed back to the existing e6 pipeline (parse + transforms + generator) using the caller's `from_sql` and `to_sql` unchanged.

## Why

Power BI Direct Query against a Databricks-tagged endpoint often emits SQL that uses Snowflake-shaped constructs (`IFF`, ANSI-quoted identifiers, etc.). Chaining SF → DBR → e6 at the planner level isn't viable because the intermediate Databricks parser rejects the SF-only syntax before it can be rewritten. With this flag the planner can ask the transpiler itself to perform the SF → DBR intermediary step, then continue through the standard e6 pipeline.

## Behaviour

| flag | input | observable result |
|---|---|---|
| off (default) | `SELECT IFF(x>0, 1, 0) FROM t`, `from_sql=snowflake`, `to_sql=e6` | `CASE WHEN x > 0 THEN 1 ELSE 0 END` (standard SF → e6) |
| on | `SELECT IFF(x>0, 1, 0) FROM t`, `from_sql=databricks`, `to_sql=e6` | `CASE WHEN x > 0 THEN 1 ELSE 0 END` (intermediary SF → DBR, then DBR → e6) |
| on | `SELECT "$Table"."col" FROM t`, `from_sql=databricks`, `to_sql=e6` | `"$Table"."col"` emitted as a quoted identifier reference end-to-end |

## Test plan

- [x] curl smoke test with flag off — confirms existing SF → e6 path unchanged
- [x] curl smoke test with flag on, `from_sql=databricks` — confirms intermediary runs and result flows through the normal pipeline
- [x] curl smoke test with `"$Table"."col"` projection — confirms the Power BI use case end-to-end
- [x] Log slice confirms the new `POWERBI_SF_TO_DBR: intermediary…` line fires only when the flag is set, followed by the standard `Transpiled Query` line from the rest of the pipeline

## Risk / scope

- One file touched (`converter_api.py`), one guarded block of 22 lines
- Flag is **off by default** — existing callers are unaffected
- Reuses `sqlglot.transpile(...)` already used by `/transpile-guardrail` (same call shape, same import), no new helpers