### PR TITLE
feat(api): fallback to original query when POWERBI_SF_TO_DBR intermediary fails

### DIFF
--- a/converter_api.py
+++ b/converter_api.py
@@ -108,23 +108,34 @@ async def convert_query(
         # Intermediary vanilla Snowflake -> Databricks transpile. The result is
         # then handed back to the normal pipeline below (parse + e6 transforms +
         # generator) using the caller's `from_sql` and `to_sql` unchanged.
+        # If the intermediary transpile fails (e.g. the input isn't actually
+        # Snowflake-shaped), fall through with the original query untouched
+        # so the downstream pipeline still gets a chance to process it.
         logger.info(
             "%s AT %s — POWERBI_SF_TO_DBR: intermediary Snowflake -> Databricks transpile",
             query_id,
             timestamp,
         )
-        query = sqlglot.transpile(
-            query,
-            read="snowflake",
-            write="databricks",
-            identify=False,
-        )[0]
-        logger.info(
-            "%s AT %s — Intermediary (SF -> DBR) result:\n%s",
-            query_id,
-            timestamp,
-            query,
-        )
+        try:
+            query = sqlglot.transpile(
+                query,
+                read="snowflake",
+                write="databricks",
+                identify=False,
+            )[0]
+            logger.info(
+                "%s AT %s — Intermediary (SF -> DBR) result:\n%s",
+                query_id,
+                timestamp,
+                query,
+            )
+        except Exception as e:
+            logger.warning(
+                "%s AT %s — Intermediary SF -> DBR failed (%s); forwarding original query to pipeline",
+                query_id,
+                timestamp,
+                e,
+            )
 
     if not query or not query.strip():
         logger.info(


### PR DESCRIPTION
## Summary

Follow-up to #261. When `POWERBI_SF_TO_DBR=true`, the transpiler runs an intermediary `sqlglot.transpile(read='snowflake', write='databricks', ...)` step before the standard DBR → e6 pipeline. Today, if that intermediary call raises (e.g. the input contains DBR-only syntax such as backtick identifiers or `LATERAL VIEW` that the SF parser rejects), the exception bubbles up and 500s the request — even though the downstream DBR → e6 pipeline could have handled the original query just fine.

This PR wraps the intermediary call in a `try/except` and on failure logs a warning, leaving `query` untouched so the rest of the handler runs as if the flag had been off.

## Behaviour

| input                                    | flag    | before                              | after                                       |
|------------------------------------------|---------|-------------------------------------|---------------------------------------------|
| valid SF query (e.g. `IFF`)              | on      | intermediary runs → DBR → e6        | unchanged                                   |
| DBR-only query (e.g. backtick names)     | on      | **500** — SF parser rejects         | warning logged, original forwarded → DBR → e6 ✓ |
| any query                                | off     | unchanged                           | unchanged                                   |

Net effect: the flag can no longer regress a query that would have transpiled cleanly without the flag.

## Test plan

- [x] Valid SF query (`IFF(x>0, 1, 0)`) with flag on — intermediary succeeds, no fallback
- [x] DBR-only query (backtick identifiers) with flag on — intermediary fails, warning logged, output identical to no-flag control
- [x] Gibberish that breaks both parsers with flag on — falls through; pipeline returns the usual 500 (no regression)
- [x] Log slice confirms `Intermediary SF -> DBR failed ...; forwarding original query to pipeline` fires only when the intermediary raises

## Risk / scope

- One file touched (`converter_api.py`), +23/-12 lines
- Affects only the `POWERBI_SF_TO_DBR` code path; default-off behaviour unchanged