### PR TITLE
fix(api): POWERBI_SF_TO_DBR fires regardless of caller's from_sql

### DIFF
--- a/converter_api.py
+++ b/converter_api.py
@@ -105,51 +105,44 @@ async def convert_query(
             return HTTPException(status_code=500, detail=str(je))
 
     if flags_dict.get("POWERBI_SF_TO_DBR", False):
-        # The flag is only meaningful when the caller actually claims the input
-        # is Snowflake. If `from_sql` is anything else, skip the intermediary
-        # entirely so we don't run a needless SF parse over a non-SF query.
-        if from_sql.lower() != "snowflake":
+        # Intermediary vanilla Snowflake -> Databricks transpile, run
+        # unconditionally whenever the flag is set -- the caller's `from_sql`
+        # is intentionally ignored so the planner can opt a query into the
+        # SF -> DBR step without first having to assert its dialect.
+        #   - on success: `query` is now Databricks-shaped (SF identifiers
+        #     turned into backticks, function renames, etc.).
+        #   - on failure: keep the original query unchanged; assume it was
+        #     already Databricks-shaped.
+        # In either case the query going into the downstream pipeline is
+        # Databricks-shaped, so override `from_sql` to "databricks" so the
+        # rest of the handler parses it with the right dialect.
+        logger.info(
+            "%s AT %s — POWERBI_SF_TO_DBR: intermediary Snowflake -> Databricks transpile (from_sql=%s ignored)",
+            query_id,
+            timestamp,
+            from_sql,
+        )
+        try:
+            query = sqlglot.transpile(
+                query,
+                read="snowflake",
+                write="databricks",
+                identify=False,
+            )[0]
             logger.info(
-                "%s AT %s — POWERBI_SF_TO_DBR ignored: from_sql=%s (flag only applies when from_sql=snowflake)",
+                "%s AT %s — Intermediary (SF -> DBR) result:\n%s",
                 query_id,
                 timestamp,
-                from_sql,
+                query,
             )
-        else:
-            # Intermediary vanilla Snowflake -> Databricks transpile.
-            #   - on success: `query` is now Databricks-shaped (SF identifiers
-            #     turned into backticks, function renames, etc.).
-            #   - on failure: keep the original query unchanged; assume it was
-            #     already Databricks-shaped.
-            # In either case the query going into the downstream pipeline is
-            # Databricks-shaped, so override `from_sql` to "databricks" so the
-            # rest of the handler parses it with the right dialect.
-            logger.info(
-                "%s AT %s — POWERBI_SF_TO_DBR: intermediary Snowflake -> Databricks transpile",
+        except Exception as e:
+            logger.warning(
+                "%s AT %s — Intermediary SF -> DBR failed (%s); forwarding original query as Databricks",
                 query_id,
                 timestamp,
+                e,
             )
-            try:
-                query = sqlglot.transpile(
-                    query,
-                    read="snowflake",
-                    write="databricks",
-                    identify=False,
-                )[0]
-                logger.info(
-                    "%s AT %s — Intermediary (SF -> DBR) result:\n%s",
-                    query_id,
-                    timestamp,
-                    query,
-                )
-            except Exception as e:
-                logger.warning(
-                    "%s AT %s — Intermediary SF -> DBR failed (%s); forwarding original query as Databricks",
-                    query_id,
-                    timestamp,
-                    e,
-                )
-            from_sql = "databricks"
+        from_sql = "databricks"
 
     if not query or not query.strip():
         logger.info(


### PR DESCRIPTION
## Summary

Revert the `from_sql=snowflake` guard added in #264. When `POWERBI_SF_TO_DBR=true`, the SF → DBR intermediary now runs unconditionally and the caller's `from_sql` is intentionally bypassed.

## Why

The previous guard required the planner to assert `from_sql=snowflake` before the flag would activate. In practice the planner doesn't always have a reliable signal that a query is Snowflake-shaped before sending it, so the guard turned the flag into a contract the planner couldn't reliably satisfy.

The existing fallback in #263 already covers the case where the intermediary fails — it forwards the original query and lets the downstream pipeline take a shot. So firing the intermediary for any `from_sql` costs only the parse attempt itself; nothing else regresses.

## Flow (when flag is on)

```
input query  ──►  sqlglot.transpile(read='snowflake', write='databricks')  ──►  DBR-shaped query
                                                                                       │
                                                                            ┌──────────┘
                                                                            ▼
                                                              from_sql := 'databricks'
                                                                            │
                                                                            ▼
                                                              normal pipeline (parse + transforms + generator)
                                                                            │
                                                                            ▼
                                                                       e6 output
```

If the SF parse raises, the original query is forwarded untouched and `from_sql` is still set to `databricks` for the downstream pipeline.

## Behaviour table

| `from_sql` (caller) | flag | intermediary | downstream `from_sql` | net effect |
|---------------------|------|--------------|------------------------|------------|
| any                 | on, intermediary succeeds | runs SF → DBR | `databricks` | DBR → e6 ✓ |
| any                 | on, intermediary fails    | fallback: original query forwarded | `databricks` | DBR → e6 if input was DBR-valid; same error otherwise |
| any                 | off  | n/a          | unchanged              | unchanged  |

## Test plan — verified locally end-to-end

Two real Power BI queries, run with `from_sql=snowflake` and `from_sql=databricks`, flag on:

| query                                              | path taken                | result |
|----------------------------------------------------|---------------------------|--------|
| Power BI risk projections (nested `$Outer/$Inner/rows`) | intermediary succeeds | e6 output with all double-quoted identifiers preserved ✓ |
| `sort_array(filter(array_agg(...), x -> x.\`value\` IS NOT NULL), ...)` | intermediary fails → fallback | downstream DBR parser produces clean e6 (`ARRAY_SORT`, `FILTER_ARRAY`, `FROM_JSON`, etc.) ✓ |

For both queries, both `from_sql=snowflake` and `from_sql=databricks` produced **identical** output, confirming the flag is genuinely `from_sql`-agnostic.

## Risk / scope

- One file (`converter_api.py`), +31 / -38 lines (mostly removing the nested if/else added in #264)
- Default-off; existing callers without the flag are unaffected
- No new dependencies, reuses `sqlglot.transpile(...)` already in the codebase