### PR TITLE
fix(e6): preserve source <> operator in NEQ

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -1386,6 +1386,23 @@ class E6(Dialect):
             "VARBINARY",
         }
 
+        def _parse_equality(self) -> t.Optional[exp.Expression]:
+            this = self._parse_comparison()
+
+            while self._match_set(self.EQUALITY):
+                klass = self.EQUALITY[self._prev.token_type]
+                token_text = self._prev.text
+                this = self.expression(
+                    klass,
+                    this=this,
+                    comments=self._prev_comments,
+                    expression=self._parse_comparison(),
+                )
+                if klass is exp.NEQ and token_text == "<>":
+                    this.meta["neq_op"] = "<>"
+
+            return this
+
         def _parse_cast(self, strict: bool, safe: t.Optional[bool] = None) -> exp.Expression:
             """
             Overrides the base class's _parse_cast method to include validation
@@ -2266,7 +2283,7 @@ class E6(Dialect):
             return self.func("NAMED_STRUCT", *flatten(zip(keys, values)))
 
         def neq_sql(self, expression: exp.NEQ) -> str:
-            return self.binary(expression, "!=")
+            return self.binary(expression, expression.meta.get("neq_op", "!="))
 
         def tochar_sql(self, expression: exp.ToChar) -> str:
             date_expr = expression.this

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -183,6 +183,17 @@ class TestE6(Validator):
         )
 
         self.validate_identity("SELECT a FROM tab WHERE a != 5")
+        self.validate_identity("SELECT a FROM tab WHERE a <> 5")
+        self.validate_all(
+            "SELECT a FROM tab WHERE a <> 5",
+            read={"e6": "SELECT a FROM tab WHERE a <> 5"},
+            write={"e6": "SELECT a FROM tab WHERE a <> 5"},
+        )
+        self.validate_all(
+            "SELECT a FROM tab WHERE a != 5",
+            read={"e6": "SELECT a FROM tab WHERE a != 5"},
+            write={"e6": "SELECT a FROM tab WHERE a != 5"},
+        )
 
         self.validate_all("SELECT DAYS('2024-11-09')", read={"trino": "SELECT DAYS('2024-11-09')"})
 


### PR DESCRIPTION
## Summary
- E6 generator previously rewrote every `NEQ` to `!=`, so source queries using `<>` round-tripped as `!=`.
- E6 parser now tags `NEQ` nodes with `meta["neq_op"] = "<>"` when the source token was `<>`; the generator's `neq_sql` reads that tag.
- `!=` behavior is unchanged when no tag is present (programmatic `exp.NEQ()` still emits `!=`).

## Scope
- Change is fully scoped to `sqlglot/dialects/e6.py` (parser override + 1-line generator tweak). No core/AST changes.
- Preservation only triggers when the source dialect is `e6`, since the source-dialect parser is the one that runs during transpile. For cross-dialect transpiles (e.g. databricks → e6), the source parser does not tag the meta, so `<>` will still emit `!=` there.

## Test plan
- [x] `pytest tests/dialects/test_e6.py` — 51 passed
- [x] Added 4 tests for `<>` and `!=` identity + explicit e6→e6 read/write in `test_E6`