### PR TITLE
fix(e6): rewrite TRY_URL_DECODE to TRY(URL_DECODE(...))

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -2454,6 +2454,9 @@ class E6(Dialect):
             ):
                 return self.sql(expression.expressions[0])
 
+            if function_name.upper() == "TRY_URL_DECODE":
+                return self.func("TRY", self.func("URL_DECODE", *expression.expressions))
+
             if function_name.upper() in function_mapping_normal:
                 # Check if the function name needs to be mapped to a different one
                 mapped_function = function_mapping_normal.get(function_name.upper(), function_name)

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -195,6 +195,11 @@ class TestE6(Validator):
             write={"e6": "SELECT a FROM tab WHERE a != 5"},
         )
 
+        self.validate_all(
+            "SELECT TRY(URL_DECODE(raw)) FROM t",
+            read={"databricks": "SELECT TRY_URL_DECODE(raw) FROM t"},
+        )
+
         self.validate_all("SELECT DAYS('2024-11-09')", read={"trino": "SELECT DAYS('2024-11-09')"})
 
         self.validate_all(


### PR DESCRIPTION
## Summary
- Databricks' `TRY_URL_DECODE(x)` was passed through unchanged into the e6 output. E6 doesn't have a single `TRY_URL_DECODE` function; the equivalent is `TRY(URL_DECODE(x))`.
- E6 generator's `anonymous_sql` now rewrites `TRY_URL_DECODE(x)` → `TRY(URL_DECODE(x))`, matching the existing `REGEXP_INSTR → INSTR` rewrite pattern in the same method.

## Example
Input (databricks):
```sql
SELECT TRY_URL_DECODE(raw) FROM t
```
Output (e6):
```sql
SELECT TRY(URL_DECODE(raw)) FROM t
```

## Scope
- Change is fully scoped to `sqlglot/dialects/e6.py` (one block in `anonymous_sql`). No core/AST changes, no impact on other dialects.

## Test plan
- [x] `make check` — 1018 tests passed, ruff + mypy clean
- [x] Added a `databricks → e6` test case for `TRY_URL_DECODE(raw)` in `test_E6`