### PR TITLE
fix(parser): tag NEQ nodes with source operator so <> can round-trip to e6

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -1386,23 +1386,6 @@ class E6(Dialect):
             "VARBINARY",
         }
 
-        def _parse_equality(self) -> t.Optional[exp.Expression]:
-            this = self._parse_comparison()
-
-            while self._match_set(self.EQUALITY):
-                klass = self.EQUALITY[self._prev.token_type]
-                token_text = self._prev.text
-                this = self.expression(
-                    klass,
-                    this=this,
-                    comments=self._prev_comments,
-                    expression=self._parse_comparison(),
-                )
-                if klass is exp.NEQ and token_text == "<>":
-                    this.meta["neq_op"] = "<>"
-
-            return this
-
         def _parse_cast(self, strict: bool, safe: t.Optional[bool] = None) -> exp.Expression:
             """
             Overrides the base class's _parse_cast method to include validation

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4994,7 +4994,21 @@ class Parser(metaclass=_Parser):
         return self._parse_tokens(self._parse_equality, self.CONJUNCTION)
 
     def _parse_equality(self) -> t.Optional[exp.Expression]:
-        return self._parse_tokens(self._parse_comparison, self.EQUALITY)
+        this = self._parse_comparison()
+
+        while self._match_set(self.EQUALITY):
+            klass = self.EQUALITY[self._prev.token_type]
+            token_text = self._prev.text
+            this = self.expression(
+                klass,
+                this=this,
+                comments=self._prev_comments,
+                expression=self._parse_comparison(),
+            )
+            if klass is exp.NEQ and token_text == "<>":
+                this.meta["neq_op"] = "<>"
+
+        return this
 
     def _parse_comparison(self) -> t.Optional[exp.Expression]:
         return self._parse_tokens(self._parse_range, self.COMPARISON)

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -183,16 +183,19 @@ class TestE6(Validator):
         )
 
         self.validate_identity("SELECT a FROM tab WHERE a != 5")
-        self.validate_identity("SELECT a FROM tab WHERE a <> 5")
         self.validate_all(
             "SELECT a FROM tab WHERE a <> 5",
-            read={"e6": "SELECT a FROM tab WHERE a <> 5"},
-            write={"e6": "SELECT a FROM tab WHERE a <> 5"},
+            read={
+                "databricks": "SELECT a FROM tab WHERE a <> 5",
+                "snowflake": "SELECT a FROM tab WHERE a <> 5",
+            },
         )
         self.validate_all(
             "SELECT a FROM tab WHERE a != 5",
-            read={"e6": "SELECT a FROM tab WHERE a != 5"},
-            write={"e6": "SELECT a FROM tab WHERE a != 5"},
+            read={
+                "databricks": "SELECT a FROM tab WHERE a != 5",
+                "snowflake": "SELECT a FROM tab WHERE a != 5",
+            },
         )
 
         self.validate_all("SELECT DAYS('2024-11-09')", read={"trino": "SELECT DAYS('2024-11-09')"})


### PR DESCRIPTION
## Summary
- Follow-up to #266. That PR preserved `<>` only for `e6 → e6` because the override lived on the e6 Parser, but during transpile the **source dialect's** parser runs — so for `databricks → e6`, `snowflake → e6`, etc., `<>` was still being emitted as `!=`.
- This change moves the meta-tagging into the base `Parser._parse_equality`. The base parser now records `meta["neq_op"] = "<>"` whenever the source token was `<>`. The redundant override in `sqlglot/dialects/e6.py` is removed.

## Why this is safe for other dialects
- The change is **strictly additive** at the AST level: it only sets metadata on the NEQ node. No other dialect's generator reads `meta["neq_op"]` — every other `neq_sql` already emits `<>` by default (see `sqlglot/generator.py`'s base `neq_sql`).
- Only e6's `neq_sql` (added in #266) consults the tag. So output for every dialect except e6 is unchanged.

## Example
Input (databricks):
```sql
SELECT * FROM t WHERE a <> 1
SELECT * FROM t WHERE a != 1
```
Output (e6) — now round-trips correctly:
```sql
SELECT * FROM t WHERE a <> 1
SELECT * FROM t WHERE a != 1
```
Previously `<>` collapsed to `!=`.

## Test plan
- [x] `make check` — 1018 tests passed, ruff + mypy clean
- [x] Replaced the prior `e6 → e6` tests with `databricks → e6` and `snowflake → e6` round-trip tests for both `<>` and `!=`