### PR TITLE
fix(postgres): map REGEXP_SPLIT_TO_ARRAY to RegexpSplit so e6 emits SPLIT

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -400,6 +400,7 @@ class Postgres(Dialect):
             "MAKE_TIMESTAMP": exp.TimestampFromParts.from_arg_list,
             "NOW": exp.CurrentTimestamp.from_arg_list,
             "REGEXP_REPLACE": _build_regexp_replace,
+            "REGEXP_SPLIT_TO_ARRAY": exp.RegexpSplit.from_arg_list,
             "TO_CHAR": build_formatted_time(exp.TimeToStr, "postgres"),
             "TO_DATE": build_formatted_time(exp.StrToDate, "postgres"),
             "TO_TIMESTAMP": _build_to_timestamp,

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -29,6 +29,13 @@ class TestE6(Validator):
         )
 
         self.validate_all(
+            "SELECT TRIM(v) AS du_id FROM (SELECT EXPLODE(SPLIT('VZ_05690013012,VZ_05690013048', ',')) AS v) AS g",
+            read={
+                "postgres": "SELECT TRIM(v) AS du_id FROM (SELECT UNNEST(REGEXP_SPLIT_TO_ARRAY('VZ_05690013012,VZ_05690013048', ',')) AS v) AS g"
+            },
+        )
+
+        self.validate_all(
             "SELECT CONVERT_TIMEZONE('America/Los_Angeles', CAST('2022-11-01 09:08:07.321' AS TIMESTAMP))",
             read={
                 "snowflake": "Select convert_timezone('America/Los_Angeles', '2022-11-01 09:08:07.321' ::TIMESTAMP)",


### PR DESCRIPTION
## Problem

Postgres `REGEXP_SPLIT_TO_ARRAY` was parsed as an anonymous function and passed through unchanged when transpiling to e6, so it stayed `REGEXP_SPLIT_TO_ARRAY` instead of becoming `SPLIT` (needed for Samsung).

## Fix

Map `REGEXP_SPLIT_TO_ARRAY` to `exp.RegexpSplit` in the Postgres parser — the same `exp.RegexpSplit.from_arg_list` pattern already used in the hive and duckdb dialects. The e6 generator already renders `exp.RegexpSplit` as `SPLIT`.

## Example

```sql
-- postgres in
SELECT TRIM(v) AS du_id FROM (SELECT UNNEST(REGEXP_SPLIT_TO_ARRAY('VZ_05690013012,VZ_05690013048', ',')) AS v) AS g

-- e6 out
SELECT TRIM(v) AS du_id FROM (SELECT EXPLODE(SPLIT('VZ_05690013012,VZ_05690013048', ',')) AS v) AS g
```

## Tests

Added an e6 round-trip test in `tests/dialects/test_e6.py`. `test_postgres` and `test_e6` pass.