### PR TITLE
revert(e6): remove TRY_URL_DECODE -> TRY(URL_DECODE(...)) rewrite

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -2437,9 +2437,6 @@ class E6(Dialect):
             ):
                 return self.sql(expression.expressions[0])
 
-            if function_name.upper() == "TRY_URL_DECODE":
-                return self.func("TRY", self.func("URL_DECODE", *expression.expressions))
-
             if function_name.upper() in function_mapping_normal:
                 # Check if the function name needs to be mapped to a different one
                 mapped_function = function_mapping_normal.get(function_name.upper(), function_name)

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -205,11 +205,6 @@ class TestE6(Validator):
             },
         )
 
-        self.validate_all(
-            "SELECT TRY(URL_DECODE(raw)) FROM t",
-            read={"databricks": "SELECT TRY_URL_DECODE(raw) FROM t"},
-        )
-
         self.validate_all("SELECT DAYS('2024-11-09')", read={"trino": "SELECT DAYS('2024-11-09')"})
 
         self.validate_all(


### PR DESCRIPTION
Removes the anonymous_sql handler that rewrote Databricks' TRY_URL_DECODE(x) to TRY(URL_DECODE(x)) along with its test.