### PR TITLE
fix(e6): render Snowflake variant navigation as E6 colon syntax

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -384,6 +384,42 @@ def _bracket_path_segments(bracket):
     return segments
 
 
+def _variant_extract_parts(expression):
+    # Resolve a Snowflake variant navigation (PARSE_JSON(c)[0]:id,
+    # PARSE_JSON(c):[0]:id, PARSE_JSON(c)::ARRAY[0]:id) into (root, segments) where
+    # `root` is the underlying variant (any redundant ::ARRAY cast stripped) and
+    # `segments` are the ordered JSON-path steps. Returns None if not a variant root.
+    this = expression.this
+    path = expression.expression
+
+    if isinstance(this, exp.Bracket) and _is_variant_root(this.this):
+        # A leading [i] index on the variant root (PARSE_JSON(c)[0]:id) — fold the
+        # bracket index in front of the colon path.
+        root = _variant_root_value(this.this)
+        lead = _bracket_path_segments(this)
+    elif _is_variant_root(this):
+        root = _variant_root_value(this)
+        lead = []
+    else:
+        return None
+
+    tail = []
+    if isinstance(path, exp.JSONPath):
+        tail = [seg for seg in path.expressions if not isinstance(seg, exp.JSONPathRoot)]
+
+    return root, [*lead, *tail]
+
+
+def _is_variant_colon_extract(node):
+    # True for a JSONExtract that navigates a parsed-JSON/variant root, i.e. one that
+    # E6 renders with colon syntax (so its wrapping CAST keeps the ::TYPE postfix form).
+    return (
+        isinstance(node, exp.JSONExtract)
+        and bool(node.args.get("variant_extract"))
+        and _variant_extract_parts(node) is not None
+    )
+
+
 def add_single_quotes(expression) -> str:
     quoted_str = f"'{expression}'"
     return quoted_str
@@ -1869,6 +1905,11 @@ class E6(Dialect):
             if expression.is_type(exp.DataType.Type.INTERVAL):
                 return self.double_colon_interval_sql(expression)
 
+            # A CAST over Snowflake variant colon navigation keeps the ::TYPE postfix
+            # form, e.g. PARSE_JSON(c):[0]:id::VARCHAR (not CAST(... AS VARCHAR)).
+            if self.from_dialect == "snowflake" and _is_variant_colon_extract(expression.this):
+                return f"{self.sql(expression.this)}::{self.sql(expression.to)}"
+
             # Delegate to base generator's cast_sql which properly uses datatype_sql
             # to handle type mappings and preserve precision/scale
             return super().cast_sql(expression, safe_prefix=safe_prefix)
@@ -2330,14 +2371,14 @@ class E6(Dialect):
             - Inside VALUES: map[...] preserved as-is (Databricks uses MAP() with
               parens for constructors, so map[...] in INSERT VALUES is not ELEMENT_AT)
             """
-            # A bracket index on a PARSE_JSON / variant root is JSON-path navigation;
-            # fold it into json_extract instead of ELEMENT_AT, which the engine rejects
-            # for the {metadata, value} variant struct PARSE_JSON produces.
-            if _is_variant_root(expression.this):
-                path = exp.JSONPath(
-                    expressions=[exp.JSONPathRoot(), *_bracket_path_segments(expression)]
+            # A bracket index on a PARSE_JSON / variant root is variant navigation, not
+            # array ELEMENT_AT (which the engine rejects for the {metadata, value}
+            # variant struct PARSE_JSON produces). Render E6 colon syntax:
+            # PARSE_JSON(c)[0] -> PARSE_JSON(c):[0].
+            if self.from_dialect == "snowflake" and _is_variant_root(expression.this):
+                return self._render_variant_colon(
+                    _variant_root_value(expression.this), _bracket_path_segments(expression)
                 )
-                return self.func("JSON_EXTRACT", _variant_root_value(expression.this), path)
 
             # Inside a VALUES clause, map[...] bracket syntax should be preserved
             # as-is. In Databricks MAP() with parens is the constructor; map[...]
@@ -2895,27 +2936,34 @@ class E6(Dialect):
                 return self.func("TO_JSON", inner.this)
             return self.func("TO_JSON", inner)
 
-        def json_extract_sql(self, e: exp.JSONExtract | exp.JSONExtractScalar):
-            # PARSE_JSON(c)[0]:id parses as JSONExtract(Bracket(PARSE_JSON(c), [0]), '$.id').
-            # Merge the leading bracket index into the front of the path so the result is a
-            # single json_extract(PARSE_JSON(c), '$[0].id') rather than ELEMENT_AT-wrapped.
-            this = e.this
-            path = e.expression
-            if (
-                isinstance(this, exp.Bracket)
-                and _is_variant_root(this.this)
-                and isinstance(path, exp.JSONPath)
-            ):
-                segments = list(path.expressions)
-                new_path = exp.JSONPath(
-                    expressions=[*segments[:1], *_bracket_path_segments(this), *segments[1:]]
-                )
-                return self.func("JSON_EXTRACT", _variant_root_value(this.this), new_path)
+        def _render_variant_colon(self, root, segments) -> str:
+            # E6 variant navigation: PARSE_JSON(c):[0]:id  (subscript -> :[i], key -> :name).
+            sql = self.sql(root)
+            for seg in segments:
+                if isinstance(seg, exp.JSONPathSubscript):
+                    sql += f":[{seg.this}]"
+                elif isinstance(seg, exp.JSONPathKey):
+                    key = seg.this
+                    if key in self.RESERVED_DATATYPE_KEYWORDS or seg.args.get("escape"):
+                        sql += f':"{key}"'
+                    else:
+                        sql += f":{key}"
+            return sql
 
+        def json_extract_sql(self, e: exp.JSONExtract | exp.JSONExtractScalar):
             # Check if this is Databricks colon syntax (marked with variant_extract=True)
             variant_extract_flag = getattr(e, "variant_extract", False) or e.args.get(
                 "variant_extract", False
             )
+
+            # Snowflake variant navigation (PARSE_JSON(c)[0]:id, PARSE_JSON(c):[0]:id,
+            # PARSE_JSON(c)::ARRAY[0]:id) -> E6 colon syntax PARSE_JSON(c):[0]:id. The
+            # leading [i] index folds into the colon path and a redundant ::ARRAY cast
+            # is dropped. (Was previously wrapped in ELEMENT_AT/JSON_EXTRACT.)
+            if self.from_dialect == "snowflake" and variant_extract_flag:
+                parts = _variant_extract_parts(e)
+                if parts is not None:
+                    return self._render_variant_colon(*parts)
 
             if self.from_dialect == "databricks" and variant_extract_flag:
                 if isinstance(e.expression, exp.JSONPath):

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -1355,36 +1355,44 @@ class TestE6(Validator):
         )
 
     def test_variant_bracket_json_path(self):
-        # A leading array index on a PARSE_JSON/variant root must fold into the JSON
-        # path, NOT become ELEMENT_AT over the PARSE_JSON variant struct (which the
-        # planner rejects for the {metadata, value} variant struct).
+        # A leading array index on a PARSE_JSON/variant root is variant navigation, not
+        # array ELEMENT_AT (which the planner rejects for the {metadata, value} variant
+        # struct). E6 renders it as colon syntax: PARSE_JSON(c)[0]:id -> PARSE_JSON(c):[0]:id.
         self.validate_all(
-            "SELECT CAST(JSON_EXTRACT(PARSE_JSON(c), '$[0].id') AS VARCHAR) AS x FROM t",
+            "SELECT PARSE_JSON(c):[0]:id::VARCHAR AS x FROM t",
             read={
                 "snowflake": "SELECT PARSE_JSON(c)[0]:id::TEXT AS x FROM t",
             },
         )
 
+        # Already-colon input is preserved (not rewritten).
+        self.validate_all(
+            "SELECT PARSE_JSON(c):[0]:id::VARCHAR AS x FROM t",
+            read={
+                "snowflake": "SELECT PARSE_JSON(c):[0]:id::TEXT AS x FROM t",
+            },
+        )
+
         # Standalone bracket on a variant root (no trailing colon path).
         self.validate_all(
-            "SELECT JSON_EXTRACT(PARSE_JSON(c), '$[0]') AS x FROM t",
+            "SELECT PARSE_JSON(c):[0] AS x FROM t",
             read={
                 "snowflake": "SELECT PARSE_JSON(c)[0] AS x FROM t",
             },
         )
 
-        # Colon-only navigation (no bracket) must remain unchanged.
+        # Colon-only navigation (no bracket).
         self.validate_all(
-            "SELECT CAST(JSON_EXTRACT(PARSE_JSON(c), '$.id') AS VARCHAR) AS x FROM t",
+            "SELECT PARSE_JSON(c):id::VARCHAR AS x FROM t",
             read={
                 "snowflake": "SELECT PARSE_JSON(c):id::TEXT AS x FROM t",
             },
         )
 
-        # A ::ARRAY cast in front of a variant index folds the index into the JSON path
-        # AND drops the redundant array cast (E6 has no CAST(... AS ARRAY)).
+        # A ::ARRAY cast in front of a variant index folds the index into the colon
+        # path AND drops the redundant array cast (E6 has no CAST(... AS ARRAY)).
         self.validate_all(
-            "SELECT CAST(JSON_EXTRACT(PARSE_JSON(c), '$[0].id') AS VARCHAR) AS x FROM t",
+            "SELECT PARSE_JSON(c):[0]:id::VARCHAR AS x FROM t",
             read={
                 "snowflake": "SELECT PARSE_JSON(c)::ARRAY[0]:id::TEXT AS x FROM t",
             },
@@ -1392,7 +1400,7 @@ class TestE6(Validator):
 
         # Real ServiceTitan dbt model (jpm_submittal): two variant-bracket columns.
         self.validate_all(
-            'SELECT T.ID, CAST(JSON_EXTRACT(PARSE_JSON(T.FIELDS_SYS_STATUS_CATEGORY_VALUE), \'$[0].id\') AS VARCHAR) AS STATUS_CATEGORY_ID, CAST(JSON_EXTRACT(PARSE_JSON(T.FIELDS_SYS_PRIORITY_VALUE), \'$[0].id\') AS VARCHAR) AS PRIORITY FROM "e6datapoc_catalogForTS"."e6datapoc.icebergForTS"."jpm_submittal" AS T LIMIT 100',
+            'SELECT T.ID, PARSE_JSON(T.FIELDS_SYS_STATUS_CATEGORY_VALUE):[0]:id::VARCHAR AS STATUS_CATEGORY_ID, PARSE_JSON(T.FIELDS_SYS_PRIORITY_VALUE):[0]:id::VARCHAR AS PRIORITY FROM "e6datapoc_catalogForTS"."e6datapoc.icebergForTS"."jpm_submittal" AS T LIMIT 100',
             read={
                 "snowflake": 'SELECT T.ID, PARSE_JSON(T.FIELDS_SYS_STATUS_CATEGORY_VALUE)[0]:id::TEXT AS STATUS_CATEGORY_ID, PARSE_JSON(T.FIELDS_SYS_PRIORITY_VALUE)[0]:id::TEXT AS PRIORITY FROM "e6datapoc_catalogForTS"."e6datapoc.icebergForTS"."jpm_submittal" T LIMIT 100',
             },
@@ -1401,7 +1409,7 @@ class TestE6(Validator):
         # Real ServiceTitan dbt model (jpm_requests_rfi): plain [0] columns plus two
         # ::ARRAY[0] columns where the redundant array cast must also be dropped.
         self.validate_all(
-            "SELECT T.ID, CAST(JSON_EXTRACT(PARSE_JSON(T.FIELDS_SYS_STATUS_CATEGORY_VALUE), '$[0].id') AS VARCHAR) AS STATUS_CATEGORY_ID, CAST(JSON_EXTRACT(PARSE_JSON(T.FIELDS_SYS_PRIORITY_VALUE), '$[0].id') AS VARCHAR) AS PRIORITY, CAST(JSON_EXTRACT(PARSE_JSON(T.FIELDS_JPM_REQUESTS_COST_IMPACT_VALUE), '$[0].id') AS VARCHAR) AS COST_IMPACT_ID, CAST(JSON_EXTRACT(PARSE_JSON(T.FIELDS_JPM_REQUESTS_SCHEDULE_IMPACT_VALUE), '$[0].id') AS VARCHAR) AS SCHEDULE_IMPACT_ID FROM \"e6datapoc_catalogForTS\".\"e6datapoc.icebergForTS\".\"jpm_requests_rfi\" AS T LIMIT 100",
+            'SELECT T.ID, PARSE_JSON(T.FIELDS_SYS_STATUS_CATEGORY_VALUE):[0]:id::VARCHAR AS STATUS_CATEGORY_ID, PARSE_JSON(T.FIELDS_SYS_PRIORITY_VALUE):[0]:id::VARCHAR AS PRIORITY, PARSE_JSON(T.FIELDS_JPM_REQUESTS_COST_IMPACT_VALUE):[0]:id::VARCHAR AS COST_IMPACT_ID, PARSE_JSON(T.FIELDS_JPM_REQUESTS_SCHEDULE_IMPACT_VALUE):[0]:id::VARCHAR AS SCHEDULE_IMPACT_ID FROM "e6datapoc_catalogForTS"."e6datapoc.icebergForTS"."jpm_requests_rfi" AS T LIMIT 100',
             read={
                 "snowflake": 'SELECT T.ID, PARSE_JSON(T.FIELDS_SYS_STATUS_CATEGORY_VALUE)[0]:id::TEXT AS STATUS_CATEGORY_ID, PARSE_JSON(T.FIELDS_SYS_PRIORITY_VALUE)[0]:id::TEXT AS PRIORITY, PARSE_JSON(T.FIELDS_JPM_REQUESTS_COST_IMPACT_VALUE)::ARRAY[0]:id::TEXT AS COST_IMPACT_ID, PARSE_JSON(T.FIELDS_JPM_REQUESTS_SCHEDULE_IMPACT_VALUE)::ARRAY[0]:id::TEXT AS SCHEDULE_IMPACT_ID FROM "e6datapoc_catalogForTS"."e6datapoc.icebergForTS"."jpm_requests_rfi" T LIMIT 100',
             },


### PR DESCRIPTION
## Problem

Snowflake variant navigation like `PARSE_JSON(c)[0]:id::TEXT` (ServiceTitan dbt models) transpiled to E6 as `ELEMENT_AT`-wrapped `JSON_EXTRACT`, which the planner rejects for the `{metadata, value}` variant struct `PARSE_JSON` returns. The `::ARRAY` columns were worse — `ELEMENT_AT(CAST(... AS ARRAY))`.

## Fix

A bracket index on a parsed-JSON/variant root is **variant navigation**, not array `ELEMENT_AT`. Render E6 colon syntax:

```
PARSE_JSON(c)[0]:id::TEXT          ->  PARSE_JSON(c):[0]:id::VARCHAR
PARSE_JSON(c):[0]:id::TEXT         ->  PARSE_JSON(c):[0]:id::VARCHAR   (already colon, preserved)
PARSE_JSON(c)::ARRAY[0]:id::TEXT   ->  PARSE_JSON(c):[0]:id::VARCHAR   (redundant ARRAY cast dropped)
```

- The leading `[i]` index folds into the colon path.
- A redundant `::ARRAY` cast is stripped (E6 has no `CAST(... AS ARRAY)`).
- The wrapping `CAST` keeps the `::TYPE` postfix form.
- Gated on `from_dialect == snowflake`.

### Implementation (`sqlglot/dialects/e6.py`)
- helpers `_variant_extract_parts` / `_is_variant_colon_extract` (plus `_is_variant_root` / `_variant_root_value` / `_bracket_path_segments`)
- `_render_variant_colon` generator method
- folds in `bracket_sql`, `json_extract_sql`, and `cast_sql` (the `::TYPE` postfix)

## Tests
`tests/dialects/test_e6.py::test_variant_bracket_json_path` — all 3 cases, colon-only, standalone bracket, plus the real ServiceTitan queries (`jpm_submittal`, `jpm_requests_rfi`). `test_e6`, `test_snowflake`, `test_databricks` pass (128 tests, 1682 subtests).

Supersedes #272.