### PR TITLE
fix(e6): emit DATE_FORMAT on native executor instead of FORMAT_DATE

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -2307,13 +2307,24 @@ class E6(Dialect):
             time_format_tokens = {"h", "hh", "s", "ss", "H", "HH", "m", "mm", "S", "SS"}
             requires_timestamp = any(token in format_expr for token in time_format_tokens)
 
+            # On native executor, map DATE_FORMAT as-is (native implements DATE_FORMAT,
+            # not the FORMAT_DATE/FORMAT_TIMESTAMP pair). On java executor (default),
+            # keep the existing FORMAT_DATE/FORMAT_TIMESTAMP split. Argument order is
+            # unchanged in both cases; only the function name differs.
+            is_native = os.getenv("E6_EXECUTOR_TYPE", "java").lower() == "native"
+            func_name = (
+                "DATE_FORMAT"
+                if is_native
+                else ("FORMAT_TIMESTAMP" if requires_timestamp else "FORMAT_DATE")
+            )
+
             if (
                 isinstance(date_expr, exp.CurrentDate)
                 or isinstance(date_expr, exp.CurrentTimestamp)
                 or isinstance(date_expr, exp.TsOrDsToDate)
             ):
                 return self.func(
-                    "FORMAT_TIMESTAMP" if requires_timestamp else "FORMAT_DATE",
+                    func_name,
                     date_expr,
                     format_expr_quoted,
                 )
@@ -2322,7 +2333,7 @@ class E6(Dialect):
             ):
                 date_expr = f"CAST({date_expr} AS DATE)"
             return self.func(
-                "FORMAT_TIMESTAMP" if requires_timestamp else "FORMAT_DATE",
+                func_name,
                 date_expr,
                 format_expr_quoted,
             )

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -2594,6 +2594,36 @@ class TestE6(Validator):
             read={"databricks": "SELECT DATE_ADD(CURRENT_TIMESTAMP, 2)"},
         )
 
+    def test_date_format_native_executor(self):
+        # With E6_EXECUTOR_TYPE=native, TimeToStr is emitted as DATE_FORMAT
+        # (native implements DATE_FORMAT, not FORMAT_DATE/FORMAT_TIMESTAMP).
+        # Default (java) keeps the FORMAT_DATE/FORMAT_TIMESTAMP split. Argument
+        # order is unchanged in both cases; only the function name differs.
+        os.environ["E6_EXECUTOR_TYPE"] = "native"
+        try:
+            # date-only format
+            self.validate_all(
+                "SELECT DATE_FORMAT(d, 'yyyy-MM-dd')",
+                read={"presto": "SELECT DATE_FORMAT(d, 'yyyy-MM-dd')"},
+            )
+            # timestamp format (time tokens) also maps to DATE_FORMAT on native
+            self.validate_all(
+                "SELECT DATE_FORMAT(CAST(d AS TIMESTAMP), 'y-MM-dd HH:mm:ss')",
+                read={"databricks": "SELECT DATE_FORMAT(d, 'yyyy-MM-dd HH:mm:ss')"},
+            )
+        finally:
+            os.environ.pop("E6_EXECUTOR_TYPE", None)
+
+        # Default (java): FORMAT_DATE for date-only, FORMAT_TIMESTAMP for time
+        self.validate_all(
+            "SELECT FORMAT_DATE(d, 'yyyy-MM-dd')",
+            read={"presto": "SELECT DATE_FORMAT(d, 'yyyy-MM-dd')"},
+        )
+        self.validate_all(
+            "SELECT FORMAT_TIMESTAMP(CAST(d AS TIMESTAMP), 'y-MM-dd HH:mm:ss')",
+            read={"databricks": "SELECT DATE_FORMAT(d, 'yyyy-MM-dd HH:mm:ss')"},
+        )
+
     def test_timestamp_seconds(self):
         # Test basic TIMESTAMP_SECONDS with integer literal
         self.validate_all(


### PR DESCRIPTION
## Problem
On the **native executor**, `FORMAT_DATE` is not implemented (`Error during planning: Function FORMAT_DATE not yet implemented`). The E6 generator renders `exp.TimeToStr` (what source-dialect `DATE_FORMAT` parses into) as `FORMAT_DATE`/`FORMAT_TIMESTAMP`, so transpiled queries that use `DATE_FORMAT` (e.g. Kantar) fail on native. Since we're moving to the native executor, the transpiler should stick to `DATE_FORMAT`.

## Change
In `format_date_sql` (`sqlglot/dialects/e6.py`), branch on `E6_EXECUTOR_TYPE` (same pattern already used by `dateadd_sql` / `to_unix_timestamp_sql`):

- **native** (`E6_EXECUTOR_TYPE=native`): render as `DATE_FORMAT` as-is — both the date and timestamp cases. Argument order is unchanged; only the function name differs.
- **java** (default): unchanged — keeps the existing `FORMAT_DATE` / `FORMAT_TIMESTAMP` split.

## Verification
Unit tests: added `test_date_format_native_executor` covering both modes; full E6 suite passes (53 tests, 893 subtests).

Validated live on a native cluster:

| Output | Native result |
|---|---|
| `DATE_FORMAT(CAST(CAST('2024-01-15' AS DATE) AS TIMESTAMP), 'y-MM-dd')` | `2024-01-15` ✓ |
| `DATE_FORMAT(CAST('2024-01-15 13:45:30' AS TIMESTAMP), 'y-MM-dd HH:mm:ss')` | `2024-01-15 13:45:30` ✓ |
| `FORMAT_DATE(...)` (old output) | ❌ `Function FORMAT_DATE not yet implemented` |

Confirms `DATE_FORMAT` handles both date and timestamp formats on native, and that the previous `FORMAT_DATE` output was the failing case.