### PR TITLE
fix(e6): parse Power BI mixed-quote SF queries via SnowflakeBackticks

### DIFF
--- a/converter_api.py
+++ b/converter_api.py
@@ -13,6 +13,7 @@ import pyarrow.parquet as pq
 import pyarrow.fs as fs
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 from sqlglot import parse_one
+from sqlglot.dialects.snowflake_backticks import SnowflakeBackticks
 from guardrail.main import StorageServiceClient
 from guardrail.main import extract_sql_components_per_table_with_alias, get_table_infos
 from guardrail.rules_validator import validate_queries
@@ -123,9 +124,15 @@ async def convert_query(
             from_sql,
         )
         try:
+            # Parse as Snowflake but tolerate Databricks backtick identifiers:
+            # Power BI queries mix ANSI double-quoted identifiers (the outer
+            # wrapper) with backtick identifiers (inner CTEs). Plain Snowflake
+            # chokes on the backticks; SnowflakeBackticks treats both " and `
+            # as identifiers, so every identifier is correctly carried over to
+            # Databricks backticks while single-quoted strings stay literals.
             query = sqlglot.transpile(
                 query,
-                read="snowflake",
+                read=SnowflakeBackticks,
                 write="databricks",
                 identify=False,
             )[0]

--- a/sqlglot/dialects/snowflake_backticks.py
+++ b/sqlglot/dialects/snowflake_backticks.py
@@ -1,0 +1,46 @@
+"""Snowflake variant that also accepts Databricks backtick identifiers.
+
+This is an e6data-specific dialect kept in its own module (rather than edited
+into the upstream ``snowflake.py``) so syncing with tobymao/main never conflicts.
+
+Why it exists
+-------------
+Power BI emits Snowflake-shaped SQL, but by the time it reaches the converter it
+can be *mixed-quoting*: the outer wrapper uses ANSI double-quoted identifiers
+(``"ID"``, ``"$Outer"``, ``GROUP BY "ID"``) while inner CTEs reference tables with
+Databricks backtick identifiers (`` `CookieTimeSeriesTransactionHeaderDayGrain` ``).
+
+- Reading it as **Databricks** is wrong: Databricks lexes ``"..."`` as a *string
+  literal*, so ``"ID"`` collapses to ``'ID'`` (a constant, not a column).
+- Reading it as plain **Snowflake** fails: Snowflake can't tokenize the backticks
+  (``ParseError``), and ``error_level`` can't rescue it — the backtick is mangled
+  at the lexer (the table name collapses to an empty identifier) before any parser
+  error handling runs.
+
+Snowflake's quote semantics are unambiguous and match Power BI exactly
+(``"`` = identifier, ``'`` = string), so the only missing piece is tolerating the
+backtick. Adding ``` ` ``` to ``IDENTIFIERS`` lets the whole mixed query parse
+correctly, with **no** risk of misreading a string literal as an identifier
+(unlike forcing ``"`` -> identifier onto Databricks).
+
+Usage
+-----
+Used only as the read dialect of the ``POWERBI_SF_TO_DBR`` intermediary
+Snowflake -> Databricks transpile in ``converter_api.py``. It is never the default
+Snowflake dialect. Reference it by the class object (not a string name) so it works
+regardless of dialect import ordering.
+"""
+
+from __future__ import annotations
+
+from sqlglot.dialects.snowflake import Snowflake
+
+
+class SnowflakeBackticks(Snowflake):
+    """Snowflake that treats both ``"`` and ``` ` ``` as quoted identifiers."""
+
+    class Tokenizer(Snowflake.Tokenizer):
+        # Snowflake default is ['"']; add the backtick so Databricks-style
+        # identifiers in a mixed Power BI query parse as identifiers. QUOTES
+        # (single-quote string literals) is inherited unchanged.
+        IDENTIFIERS = ['"', "`"]

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -3219,6 +3219,53 @@ class TestE6(Validator):
             },
         )
 
+    def test_powerbi_mixed_quote_sf_to_dbr(self):
+        """Power BI SF->DBR->E6 path for mixed-quote queries.
+
+        Power BI Snowflake SQL mixes ANSI double-quoted identifiers (outer
+        wrapper) with Databricks backtick identifiers (inner CTEs). Parsing as
+        SnowflakeBackticks (which accepts both " and ` as identifiers) keeps
+        every identifier an identifier and every single-quoted string a literal,
+        then the existing Databricks->E6 step renders them as E6 identifiers.
+        """
+        import sqlglot
+        from sqlglot.dialects.snowflake_backticks import SnowflakeBackticks
+
+        def sf_backtick_to_e6(sql):
+            dbr = sqlglot.transpile(
+                sql, read=SnowflakeBackticks, write="databricks", identify=False
+            )[0]
+            return sqlglot.transpile(dbr, read="databricks", write="e6")[0]
+
+        # Mixed: backtick-quoted table + ANSI double-quoted identifiers +
+        # single-quoted literal. Identifiers stay identifiers; 'lit' stays a literal.
+        self.assertEqual(
+            sf_backtick_to_e6(
+                'SELECT "ID" AS "c47", "k" FROM cat.`MyTbl` WHERE "k" = \'lit\' GROUP BY "ID"'
+            ),
+            'SELECT "ID" AS "c47", "k" FROM cat."MyTbl" WHERE "k" = \'lit\' GROUP BY "ID"',
+        )
+
+        # Standalone double-quoted identifier in projection and GROUP BY must NOT
+        # become the string literal 'ID'.
+        self.assertEqual(
+            sf_backtick_to_e6('SELECT "ID" FROM cat.`Tbl` GROUP BY "ID"'),
+            'SELECT "ID" FROM cat."Tbl" GROUP BY "ID"',
+        )
+
+        # Single-quoted string stays a literal.
+        self.assertEqual(
+            sf_backtick_to_e6("SELECT 'hello' AS x FROM t"),
+            "SELECT 'hello' AS x FROM t",
+        )
+
+        # Regression: base Snowflake (no backtick variant) already treats "ID" as
+        # an identifier, so default behavior is unchanged.
+        self.assertEqual(
+            sqlglot.transpile('SELECT "ID" FROM t', read="snowflake", write="e6")[0],
+            'SELECT "ID" FROM t',
+        )
+
     def test_make_interval(self):
         """Test make_interval transpilation from Databricks to E6."""
 


### PR DESCRIPTION
## Problem

Power BI Snowflake SQL sent through the `POWERBI_SF_TO_DBR` path is **mixed-quoting**: ANSI double-quoted identifiers in the outer wrapper (`"ID"`, `"$Outer"`, `GROUP BY "ID"`) plus Databricks **backtick** identifiers in inner CTEs (```CookieTimeSeriesTransactionHeaderDayGrain```).

The intermediary Snowflake→Databricks transpile **fails** on the backticks (`ParseError`), falls back to a plain databricks parse, and databricks lexes `"..."` as a **string literal** — so `"ID"` collapsed to `'ID'` (a constant) and `GROUP BY "ID"` became `GROUP BY 'ID'`. Wrong query.

## Fix

Add a **`SnowflakeBackticks`** dialect — a `Snowflake` subclass that overrides only the tokenizer identifiers (`['"', '`']`) — in its own module `sqlglot/dialects/snowflake_backticks.py` (kept out of upstream `snowflake.py` so tobymao syncs don't conflict). Use it as the read dialect of the `POWERBI_SF_TO_DBR` intermediary transpile.

Snowflake's quote semantics are **unambiguous and match Power BI exactly** (`"` = identifier, `'` = string), so every identifier is carried over to databricks backticks correctly with **no risk of misreading a string as an identifier** (unlike forcing `"`→identifier onto databricks). The backtick table names parse too. Downstream `from_dialect` stays `databricks`.

Rejected alternatives: `error_level` (silently collapses the backtick table name to an empty identifier); global `PRESERVE_DOUBLE_QUOTES_AROUND_IDENTIFIERS_DBR` (corrupts genuine double-quoted string literals in other databricks queries).

## Verification

End-to-end on the real ServiceTitan/Power BI query (10 CASE columns, ~43-col inner subquery): identifiers stay identifiers, single-quoted strings stay literals, backtick tables → E6 identifiers, `GROUP BY "ID"`, all 10 CASE columns intact, E6 round-trips. Old databricks path reproduces the `'ID'` bug.

## Tests

`tests/dialects/test_e6.py::test_powerbi_mixed_quote_sf_to_dbr` (mixed query, standalone `"ID"`, literal preservation, base-snowflake regression). `test_e6`, `test_snowflake`, `test_databricks`, dialect-imports, tokens, parser all pass (619 tests, 8488 subtests).