### PR TITLE
fix(e6): emit TO_UNIX_TIMESTAMP with format arg on native executor

### DIFF
--- a/sqlglot/dialects/e6.py
+++ b/sqlglot/dialects/e6.py
@@ -2797,14 +2797,18 @@ class E6(Dialect):
 
             # Generate final function with or without format argument
             if format_str:
+                # Native executor doesn't implement PARSE_DATETIME, but its
+                # TO_UNIX_TIMESTAMP accepts the format directly as a second
+                # argument (Spark-style pattern), so emit
+                # TO_UNIX_TIMESTAMP(<expr>, '<format>') and skip PARSE_DATETIME.
+                if is_native:
+                    return self.func("TO_UNIX_TIMESTAMP", time_expr, self.format_time(expression))
                 parse_datetime_expr = exp.Anonymous(
                     this="PARSE_DATETIME", expressions=[exp.Literal.string(format_str), time_expr]
                 )
                 to_unix_expr = exp.Anonymous(
                     this="TO_UNIX_TIMESTAMP", expressions=[parse_datetime_expr]
                 )
-                if is_native:
-                    return self.sql(to_unix_expr)
                 return self.sql(exp.Div(this=to_unix_expr, expression=exp.Literal.number("1000")))
 
             # Wrap argument in CAST(... AS TIMESTAMP) since E6's TO_UNIX_TIMESTAMP

--- a/tests/dialects/test_e6.py
+++ b/tests/dialects/test_e6.py
@@ -2552,10 +2552,18 @@ class TestE6(Validator):
                 "SELECT TO_UNIX_TIMESTAMP(CAST(A AS TIMESTAMP))",
                 read={"databricks": "SELECT UNIX_TIMESTAMP(A)"},
             )
-            # format branch (PARSE_DATETIME)
+            # format branch: native has no PARSE_DATETIME, so the format is passed
+            # directly as TO_UNIX_TIMESTAMP's 2nd arg (Spark-style pattern) instead.
             self.validate_all(
-                "SELECT TO_UNIX_TIMESTAMP(PARSE_DATETIME('%Y-%m-%d', '2016-04-08'))",
+                "SELECT TO_UNIX_TIMESTAMP('2016-04-08', 'yyyy-MM-dd')",
                 read={"databricks": "SELECT unix_timestamp('2016-04-08', 'yyyy-MM-dd')"},
+            )
+            # reported case: from_unixtime(unix_timestamp(col, 'yyyyMMdd'))
+            self.validate_all(
+                'SELECT FROM_UNIXTIME(TO_UNIX_TIMESTAMP("t"."day_id", \'yyyyMMdd\'))',
+                read={
+                    "databricks": "SELECT from_unixtime(unix_timestamp(`t`.`day_id`, 'yyyyMMdd'))"
+                },
             )
         finally:
             os.environ.pop("E6_EXECUTOR_TYPE", None)


### PR DESCRIPTION
## What

On the **native executor**, `unix_timestamp(col, fmt)` was transpiled by wrapping the value in `PARSE_DATETIME`, which the native executor does not implement.

```
from_unixtime(unix_timestamp(`v_cm_invt_fw_5g_wide`.`day_id`, 'yyyyMMdd'))
```

- **before (native):** `FROM_UNIXTIME(TO_UNIX_TIMESTAMP(PARSE_DATETIME('%Y%m%d', "v_cm_invt_fw_5g_wide"."day_id")))`
- **after (native):** `FROM_UNIXTIME(TO_UNIX_TIMESTAMP("v_cm_invt_fw_5g_wide"."day_id", 'yyyyMMdd'))`

The format is now passed directly as `TO_UNIX_TIMESTAMP`'s second argument (Spark-style pattern), reusing the existing `format_time` inverse mapping (`%Y%m%d` → `yyyyMMdd`). No `PARSE_DATETIME`.

The **java (default) executor path is unchanged** (`PARSE_DATETIME(...) / 1000`).

## Verification

Live on the native cluster:
- `...TO_UNIX_TIMESTAMP(PARSE_DATETIME('%Y%m%d', '20240115'))` → `Function PARSE_DATETIME not yet implemented`
- `...TO_UNIX_TIMESTAMP('20240115', 'yyyyMMdd')` → `2024-01-15T00:00:00.000+00:00` ✅

`make check` passes (ruff, mypy, 970 tests × 2). Updated `test_unix_timestamp_native_executor` and added the reported `from_unixtime(unix_timestamp(col, 'yyyyMMdd'))` case.